### PR TITLE
Support for custom syntax highlighting

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -8,6 +8,14 @@ module.exports = function (data, options) {
     new MdIt(opt) :
     new MdIt(opt.render);
 
+  if (opt.render && opt.render.highlight) {
+    var highlight = opt.render.highlight;
+    if (typeof highlight === 'string') {
+      highlight = require(highlight);
+    }
+    parser.set({ highlight: highlight });
+  }
+
   if (opt.plugins) {
     parser = opt.plugins.reduce(function (parser, pugs) {
       return parser.use(require(pugs));

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "gulp-load-plugins": "^0.10.0",
     "gulp-mocha": "^2.0.1",
     "jshint-stylish": "^1.0.1",
-    "mocha": "^2.2.4"
+    "mocha": "^2.2.4",
+    "codemirror-highlight-node": "^1.0.2"
   }
 }

--- a/test/fixtures/highlight.md
+++ b/test/fixtures/highlight.md
@@ -1,0 +1,7 @@
+``` javascript
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+```

--- a/test/fixtures/outputs/highlight.html
+++ b/test/fixtures/outputs/highlight.html
@@ -1,0 +1,6 @@
+<pre><code class="language-javascript"><span class="cm-keyword">var</span> <span class="cm-variable">foo</span> <span class="cm-operator">=</span> <span class="cm-keyword">function</span> (<span class="cm-def">bar</span>) {
+  <span class="cm-keyword">return</span> <span class="cm-variable-2">bar</span><span class="cm-operator">++</span>;
+};
+
+<span class="cm-variable">console</span>.<span class="cm-property">log</span>(<span class="cm-variable">foo</span>(<span class="cm-number">5</span>));
+</code></pre>

--- a/test/index.js
+++ b/test/index.js
@@ -91,6 +91,47 @@ describe('Hexo Renderer Markdown-it', function () {
     result.should.equal(parsed_custom);
   });
 
+  it('should handle a custom highlight function', function () {
+    var highlight = require('codemirror-highlight-node');
+    var parsed_highlight = fs.readFileSync('./test/fixtures/outputs/highlight.html', 'utf8');
+    var ctx = {
+      config: {
+        markdown: {
+          render: {
+            highlight: function (code, lang) { return highlight(code,lang); }
+          }
+        }
+      }
+    };
+    var source = fs.readFileSync('./test/fixtures/highlight.md', 'utf8');
+    var parse = render.bind(ctx);
+    var result = parse({
+      text: source
+    });
+    ctx = {};
+    result.should.equal(parsed_highlight);
+  });
+
+  it('should handle a custom highlight module', function () {
+    var parsed_highlight = fs.readFileSync('./test/fixtures/outputs/highlight.html', 'utf8');
+    var ctx = {
+      config: {
+        markdown: {
+          render: {
+            highlight: 'codemirror-highlight-node'
+          }
+        }
+      }
+    };
+    var source = fs.readFileSync('./test/fixtures/highlight.md', 'utf8');
+    var parse = render.bind(ctx);
+    var result = parse({
+      text: source
+    });
+    ctx = {};
+    result.should.equal(parsed_highlight);
+  });
+
   it('should render plugins if they are defined', function () {
     var parsed_plugins = fs.readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
     var ctx = {


### PR DESCRIPTION
Hi,

this patch will allow user to provide custom function or module for syntax highlighting.
Markdown-it uses by default [highlightjs](https://highlightjs.org/). It's not bad but there are better solutions, for example [CodeMirror](http://codemirror.net/).

_API change:_
new `highlight` option:  must be `function(source, lang) -> string` or name of available module which exports such function.

For testing purpose I've added highlighting using codemirror to dev dependencies.
