### PR TITLE
add support for markdown-it-classy

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "lodash.assign": "^3.2.0",
     "markdown-it": "^5.0.1",
     "markdown-it-abbr": "^1.0.0",
+    "markdown-it-classy": "^0.2.0",
     "markdown-it-footnote": "^2.0.0",
     "markdown-it-ins": "^2.0.0",
     "markdown-it-sub": "^1.0.0",

--- a/test/fixtures/markdownit.md
+++ b/test/fixtures/markdownit.md
@@ -216,6 +216,28 @@ It converts "HTML", but keep intact partial entries like "xxxHTMLyyy" and so on.
 
 *[HTML]: Hyper Text Markup Language
 
+
+### [CSS Classes](https://github.com/andrey-p/markdown-it-classy)
+
+#### All kinds of headings work! {classy_heading}
+
+_em {classy}_ and __strong {classy}__ are not supported!
+{classy_paragraph}
+
+- so
+- are {classy_item}
+- ul tags
+{classy_list}
+
+> blockquotes?
+> {classy_paragraph}
+>
+> why not!
+{classy_blockquote}
+
+So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.
+
+
 ### [Custom containers](https://github.com/markdown-it/markdown-it-container)
 
 ::: warning

--- a/test/fixtures/outputs/anchors.html
+++ b/test/fixtures/outputs/anchors.html
@@ -177,6 +177,23 @@ Third paragraph of definition 2.
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
+<h3 id="css-classes"><a class="header-anchor" href="#css-classes">¶</a><a href="https://github.com/andrey-p/markdown-it-classy">CSS Classes</a></h3>
+<h4 id="all-kinds-of-headings-work-classy-heading"><a class="header-anchor" href="#all-kinds-of-headings-work-classy-heading">¶</a>All kinds of headings work! {classy_heading}</h4>
+<p><em>em {classy}</em> and <strong>strong {classy}</strong> are not supported!
+{classy_paragraph}</p>
+<ul>
+<li>so</li>
+<li>are {classy_item}</li>
+<li>ul tags
+{classy_list}</li>
+</ul>
+<blockquote>
+<p>blockquotes?
+{classy_paragraph}</p>
+<p>why not!
+{classy_blockquote}</p>
+</blockquote>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.</p>
 <h3 id="custom-containers"><a class="header-anchor" href="#custom-containers">¶</a><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning
 <em>here be dragons</em>

--- a/test/fixtures/outputs/commonmark.html
+++ b/test/fixtures/outputs/commonmark.html
@@ -143,6 +143,23 @@ Third paragraph of definition 2.
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
+<h3><a href="https://github.com/andrey-p/markdown-it-classy">CSS Classes</a></h3>
+<h4>All kinds of headings work! {classy_heading}</h4>
+<p><em>em {classy}</em> and <strong>strong {classy}</strong> are not supported!
+{classy_paragraph}</p>
+<ul>
+<li>so</li>
+<li>are {classy_item}</li>
+<li>ul tags
+{classy_list}</li>
+</ul>
+<blockquote>
+<p>blockquotes?
+{classy_paragraph}</p>
+<p>why not!
+{classy_blockquote}</p>
+</blockquote>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.</p>
 <h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning
 <em>here be dragons</em>

--- a/test/fixtures/outputs/custom.html
+++ b/test/fixtures/outputs/custom.html
@@ -177,6 +177,23 @@ Third paragraph of definition 2.
 <p>This is HTML abbreviation example.</p>
 <p>It converts «HTML», but keep intact partial entries like «xxxHTMLyyy» and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
+<h3><a href="https://github.com/andrey-p/markdown-it-classy">CSS Classes</a></h3>
+<h4>All kinds of headings work! {classy_heading}</h4>
+<p><em>em {classy}</em> and <strong>strong {classy}</strong> are not supported!<br />
+{classy_paragraph}</p>
+<ul>
+<li>so</li>
+<li>are {classy_item}</li>
+<li>ul tags<br />
+{classy_list}</li>
+</ul>
+<blockquote>
+<p>blockquotes?<br />
+{classy_paragraph}</p>
+<p>why not!<br />
+{classy_blockquote}</p>
+</blockquote>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it’s inline, it’s applied to the inner element.</p>
 <h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning<br />
 <em>here be dragons</em><br />

--- a/test/fixtures/outputs/default.html
+++ b/test/fixtures/outputs/default.html
@@ -177,6 +177,23 @@ Third paragraph of definition 2.
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
+<h3><a href="https://github.com/andrey-p/markdown-it-classy">CSS Classes</a></h3>
+<h4>All kinds of headings work! {classy_heading}</h4>
+<p><em>em {classy}</em> and <strong>strong {classy}</strong> are not supported!
+{classy_paragraph}</p>
+<ul>
+<li>so</li>
+<li>are {classy_item}</li>
+<li>ul tags
+{classy_list}</li>
+</ul>
+<blockquote>
+<p>blockquotes?
+{classy_paragraph}</p>
+<p>why not!
+{classy_blockquote}</p>
+</blockquote>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.</p>
 <h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning
 <em>here be dragons</em>

--- a/test/fixtures/outputs/plugins.html
+++ b/test/fixtures/outputs/plugins.html
@@ -172,6 +172,19 @@ Third paragraph of definition 2.
 <h3><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is <abbr title="Hyper Text Markup Language">HTML</abbr> abbreviation example.</p>
 <p>It converts &quot;<abbr title="Hyper Text Markup Language">HTML</abbr>&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
+<h3><a href="https://github.com/andrey-p/markdown-it-classy">CSS Classes</a></h3>
+<h4 class="classy_heading">All kinds of headings work!</h4>
+<p class="classy_paragraph"><em>em {classy}</em> and <strong>strong {classy}</strong> are not supported!</p>
+<ul class="classy_list">
+<li>so</li>
+<li class="classy_item">are</li>
+<li>ul tags</li>
+</ul>
+<blockquote class="classy_blockquote">
+<p class="classy_paragraph">blockquotes?</p>
+<p>why not!</p>
+</blockquote>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.</p>
 <h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning
 <em>here be dragons</em>

--- a/test/fixtures/outputs/zero.html
+++ b/test/fixtures/outputs/zero.html
@@ -118,6 +118,20 @@ with lazy continuation.</p>
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
+<p>### [CSS Classes](https://github.com/andrey-p/markdown-it-classy)</p>
+<p>#### All kinds of headings work! {classy_heading}</p>
+<p>_em {classy}_ and __strong {classy}__ are not supported!
+{classy_paragraph}</p>
+<p>- so
+- are {classy_item}
+- ul tags
+{classy_list}</p>
+<p>&gt; blockquotes?
+&gt; {classy_paragraph}
+&gt;
+&gt; why not!
+{classy_blockquote}</p>
+<p>So basically, if the class statement is after a newline, it gets applied to the outer element, and if it's inline, it's applied to the inner element.</p>
 <p>### [Custom containers](https://github.com/markdown-it/markdown-it-container)</p>
 <p>::: warning
 *here be dragons*

--- a/test/index.js
+++ b/test/index.js
@@ -105,7 +105,7 @@ describe('Hexo Renderer Markdown-it', function () {
             typographer: false,
             quotes: '«»“”'
           },
-          plugins: ['markdown-it-footnote', 'markdown-it-sub', 'markdown-it-sup', 'markdown-it-ins', 'markdown-it-abbr']
+          plugins: ['markdown-it-classy', 'markdown-it-footnote', 'markdown-it-sub', 'markdown-it-sup', 'markdown-it-ins', 'markdown-it-abbr']
         }
       }
     };


### PR DESCRIPTION
BTW there's an issue which remains:

``` md
_em {classy}_ and __strong {classy}__ are supported as well.
```

**does not** convert to

``` html
<p><em class="classy">em</em> and <strong class="classy">strong</strong> are supported as well.
```
