### PR TITLE
Add markdown-it-cjk-breaks plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
   "homepage": "https://github.com/hexojs/hexo-renderer-markdown-it",
   "dependencies": {
     "lodash.assign": "^4.2.0",
-    "markdown-it": "^8.4.0",
+    "markdown-it": "^8.4.1",
     "markdown-it-abbr": "^1.0.4",
+    "markdown-it-cjk-breaks": "^1.1.0",
     "markdown-it-container": "^2.0.0",
     "markdown-it-deflist": "^2.0.3",
     "markdown-it-emoji": "^1.4.0",


### PR DESCRIPTION
A new official markdown-it plugin, [repository here](https://github.com/markdown-it/markdown-it-cjk-breaks).