### PR TITLE
chore: specify files to packaging

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.jshintrc
-.travis.yml
-gulpfile.js
-.idea/
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hexo-renderer-markdown-it",
   "version": "3.4.2",
   "description": "Markdown-it is a Markdown parser, done right. A faster and CommonMark compliant alternative for Hexo.",
-  "main": "index",
+  "main": "index.js",
   "scripts": {
     "eslint": "eslint .",
     "test": "mocha test/index.js",
@@ -19,7 +19,11 @@
     "markdown-it",
     "hexo-renderer"
   ],
+  "directories": {
+    "lib": "./lib"
+  },
   "files": [
+    "index.js",
     "lib/"
   ],
   "author": "Celso Miranda <contacto@celsomiranda.net> (http://celsomiranda.net/)",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "markdown-it",
     "hexo-renderer"
   ],
+  "files": [
+    "lib/"
+  ],
   "author": "Celso Miranda <contacto@celsomiranda.net> (http://celsomiranda.net/)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
`npm publish --dry-run` result is following.

```sh
$ npm publish --dry-run
npm notice
npm notice package: hexo-renderer-markdown-it@3.4.2
npm notice === Tarball Contents ===
npm notice 1.5kB package.json
npm notice 1.1kB LICENSE
npm notice 1.9kB README.md
npm notice 1.9kB lib/anchors.js
npm notice 692B  lib/renderer.js
```