### PR TITLE
fix: set default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ markdown:
   plugins:
   anchors:
     level: 2
-    collisionSuffix: 'v'
+    collisionSuffix: ''
 ```
 
 Refer to [the wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki) for more details.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 
 This renderer plugin uses [Markdown-it] as a render engine on [Hexo]. Adds support for [Markdown] and [CommonMark].
 
-## Documentation
-This `README` was getting too messy for my taste, so it was time to fire up the github wiki in the repo and [move the documentation over there](https://github.com/hexojs/hexo-renderer-markdown-it/wiki).
-
 ## Main Features
 - Support for [Markdown], [GFM] and [CommonMark]
 - Extensive configuration
@@ -22,12 +19,29 @@ This `README` was getting too messy for my taste, so it was time to fire up the 
 - `<ins>` <ins>Inserted</ins>
 
 ## Installation
-You can install `hexo-renderer-markdown-it` by following [these steps in the documentation](https://github.com/hexojs/hexo-renderer-markdown-it/wiki/Getting-Started).
+Follow the [installation guide](https://github.com/hexojs/hexo-renderer-markdown-it/wiki/Getting-Started).
 
-It's also the place to go if you want to know more about how `hexo-renderer-markdown-it` works.
+## Options
+
+``` yml
+markdown:
+  render:
+    html: true
+    xhtmlOut: false
+    breaks: true
+    linkify: true
+    typographer: true
+    quotes: '“”‘’'
+  plugins:
+  anchors:
+    level: 2
+    collisionSuffix: 'v'
+```
+
+Refer to [the wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki) for more details.
 
 ## Requests and bug reports
-If you have any feature requests or bugs to report, [you're welcome to file an issue](https://github.com/hexojs/hexo-renderer-markdown-it/issues).
+If you have any feature requests or bugs to report, you're welcome to [file an issue](https://github.com/hexojs/hexo-renderer-markdown-it/issues).
 
 
 [CommonMark]: http://commonmark.org/

--- a/index.js
+++ b/index.js
@@ -2,6 +2,21 @@
 
 'use strict';
 
+hexo.config.markdown = Object.assign({
+  render: {
+    html: true,
+    xhtmlOut: false,
+    breaks: false,
+    linkify: true,
+    typographer: true,
+    quotes: '“”‘’'
+  },
+  anchors: {
+    level: 2,
+    collisionSuffix: 'v'
+  }
+}, hexo.config.markdown);
+
 const renderer = require('./lib/renderer');
 
 hexo.extend.renderer.register('md', 'html', renderer, true);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ hexo.config.markdown = Object.assign({
   },
   anchors: {
     level: 2,
-    collisionSuffix: 'v'
+    collisionSuffix: ''
   }
 }, hexo.config.markdown);
 


### PR DESCRIPTION
mainly to enable anchor links to be compatible with [`toc()`](https://hexo.io/docs/helpers#toc) helper. Fixes https://github.com/theme-next/hexo-theme-next/issues/1168

All defaults are set in consistent with [hexo-renderer-marked](https://github.com/hexojs/hexo-renderer-marked).

cc @anthonyhan