### PR TITLE
fix: handle defaults correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ markdown:
   anchors:
     level: 2
     collisionSuffix: ''
+    permalink: false,
+    permalinkClass: 'header-anchor'
+    permalinkSymbol: '¶'
 ```
 
 Refer to [the wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki) for more details.

--- a/index.js
+++ b/index.js
@@ -2,20 +2,22 @@
 
 'use strict';
 
-hexo.config.markdown = Object.assign({
-  render: {
-    html: true,
-    xhtmlOut: false,
-    breaks: true,
-    linkify: true,
-    typographer: true,
-    quotes: '“”‘’'
-  },
-  anchors: {
-    level: 2,
-    collisionSuffix: ''
-  }
-}, hexo.config.markdown);
+hexo.config.markdown.render = Object.assign({
+  html: true,
+  xhtmlOut: false,
+  breaks: true,
+  linkify: true,
+  typographer: true,
+  quotes: '“”‘’'
+}, hexo.config.markdown.render);
+
+hexo.config.markdown.anchors = Object.assign({
+  level: 2,
+  collisionSuffix: '',
+  permalink: false,
+  permalinkClass: 'header-anchor',
+  permalinkSymbol: '¶'
+}, hexo.config.markdown.anchors);
 
 const renderer = require('./lib/renderer');
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,11 @@
 
 'use strict';
 
+hexo.config.markdown = Object.assign({
+  render: {},
+  anchors: {}
+}, hexo.config.markdown);
+
 hexo.config.markdown.render = Object.assign({
   html: true,
   xhtmlOut: false,

--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -14,7 +14,7 @@ const renderPermalink = function(slug, opts, tokens, idx) {
 };
 
 const anchor = function(md, opts) {
-  opts = Object.assign({}, anchor.defaults, opts);
+ Object.assign(opts, { renderPermalink });
 
   const titleStore = {};
   const originalHeadingOpen = md.renderer.rules.heading_open;
@@ -51,15 +51,6 @@ const anchor = function(md, opts) {
       ? originalHeadingOpen.apply(this, args)
       : self.renderToken.apply(self, args);
   };
-};
-
-anchor.defaults = {
-  level: 1,
-  collisionSuffix: 'v',
-  permalink: false,
-  renderPermalink: renderPermalink,
-  permalinkClass: 'header-anchor',
-  permalinkSymbol: '¶'
 };
 
 module.exports = anchor;

--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -31,7 +31,7 @@ const anchor = function(md, opts) {
 
       let slug = sluggo(title);
 
-      if (Object.prototype.isPrototypeOf.call(titleStore, slug)) {
+      if (Object.prototype.hasOwnProperty.call(titleStore, slug)) {
         titleStore[slug] = titleStore[slug] + 1;
         slug = slug + '-' + opts.collisionSuffix + titleStore[slug].toString();
       } else {

--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -14,7 +14,7 @@ const renderPermalink = function(slug, opts, tokens, idx) {
 };
 
 const anchor = function(md, opts) {
- Object.assign(opts, { renderPermalink });
+  Object.assign(opts, { renderPermalink });
 
   const titleStore = {};
   const originalHeadingOpen = md.renderer.rules.heading_open;

--- a/test/fixtures/outputs/anchors.html
+++ b/test/fixtures/outputs/anchors.html
@@ -6,9 +6,9 @@
 <h6 id="h6-heading"><a class="header-anchor" href="#h6-heading">¶</a>h6 Heading</h6>
 <h2 id="horizontal-rule"><a class="header-anchor" href="#horizontal-rule">¶</a>Horizontal Rule</h2>
 <hr>
-<h2 id="horizontal-rule"><a class="header-anchor" href="#horizontal-rule">¶</a>Horizontal Rule</h2>
+<h2 id="horizontal-rule-ver2"><a class="header-anchor" href="#horizontal-rule-ver2">¶</a>Horizontal Rule</h2>
 <hr>
-<h2 id="horizontal-rule"><a class="header-anchor" href="#horizontal-rule">¶</a>Horizontal Rule</h2>
+<h2 id="horizontal-rule-ver3"><a class="header-anchor" href="#horizontal-rule-ver3">¶</a>Horizontal Rule</h2>
 <hr>
 <h2 id="typographic-replacements"><a class="header-anchor" href="#typographic-replacements">¶</a>Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,7 @@ describe('Hexo Renderer Markdown-it', () => {
         markdown: {
           anchors: {
             level: 1,
+            collisionSuffix: '',
             permalink: false,
             permalinkClass: 'header-anchor',
             permalinkSymbol: '¶'
@@ -196,7 +197,7 @@ describe('Hexo Renderer Markdown-it', () => {
         }
       }
     };
-    const anchorsNoPerm = '<h1 id="this-is-an-h1-title">This is an H1 title</h1>\n<h1 id="this-is-an-h1-title">This is an H1 title</h1>\n';
+    const anchorsNoPerm = '<h1 id="this-is-an-h1-title">This is an H1 title</h1>\n<h1 id="this-is-an-h1-title-2">This is an H1 title</h1>\n';
     const anchorsNoPerm_parse = render.bind(ctx);
     const anchorsNoPerm_result = anchorsNoPerm_parse({
       text: '# This is an H1 title\n# This is an H1 title'


### PR DESCRIPTION
noticed `Object.assign()` doesn't do deep cloning,

In the following config, the defaults `level` and `collisionSuffix` are not parsed to the plugin in current behavior.

``` yml
markdown:
  anchors:
    permalink: true
```

This PR ensure defaults are handled correctly, so that `level` and `collisionSuffix` are retained.

---

also fixed an issue where duplicate titles are not handled correctly, should be `Object.prototype.hasOwnProperty()`, not `Object.prototype.isPrototypeOf()`