### PR TITLE
fix(anchors): utilize slugize() of hexo-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ markdown:
     permalink: false,
     permalinkClass: 'header-anchor'
     permalinkSymbol: '¶'
+    case: 0
+    separator: ''
 ```
 
 Refer to [the wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki) for more details.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ hexo.config.markdown.anchors = Object.assign({
   permalink: false,
   permalinkClass: 'header-anchor',
   permalinkSymbol: '¶',
-  case: 0
+  case: 0,
+  separator: ''
 }, hexo.config.markdown.anchors);
 
 const renderer = require('./lib/renderer');

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ hexo.config.markdown.anchors = Object.assign({
   collisionSuffix: '',
   permalink: false,
   permalinkClass: 'header-anchor',
-  permalinkSymbol: '¶'
+  permalinkSymbol: '¶',
+  case: 0
 }, hexo.config.markdown.anchors);
 
 const renderer = require('./lib/renderer');

--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Token = require('markdown-it/lib/token');
-const sluggo = require('sluggo');
+const { slugize } = require('hexo-util');
 
 const renderPermalink = function(slug, opts, tokens, idx) {
   return tokens[idx + 1].children.unshift(Object.assign(new Token('link_open', 'a', 1), {
@@ -18,6 +18,7 @@ const anchor = function(md, opts) {
 
   const titleStore = {};
   const originalHeadingOpen = md.renderer.rules.heading_open;
+  const slugOpts = { transform: opts.case, ...opts };
 
   md.renderer.rules.heading_open = function(...args) {
     const [tokens, idx, something, somethingelse, self] = args; // eslint-disable-line no-unused-vars
@@ -29,7 +30,7 @@ const anchor = function(md, opts) {
         return acc + t.content;
       }, '');
 
-      let slug = sluggo(title);
+      let slug = slugize(title, slugOpts);
 
       if (Object.prototype.hasOwnProperty.call(titleStore, slug)) {
         titleStore[slug] = titleStore[slug] + 1;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/hexojs/hexo-renderer-markdown-it",
   "dependencies": {
+    "hexo-util": "^1.7.0",
     "markdown-it": "^10.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-cjk-breaks": "^1.1.2",

--- a/test/fixtures/outputs/anchors.html
+++ b/test/fixtures/outputs/anchors.html
@@ -1,28 +1,28 @@
 <h1>h1 Heading em português</h1>
-<h2 id="h2-heading-p"><a class="header-anchor" href="#h2-heading-p">¶</a>h2 Heading :P</h2>
-<h3 id="h3-heading"><a class="header-anchor" href="#h3-heading">¶</a>h3 Heading</h3>
-<h4 id="h4-heading"><a class="header-anchor" href="#h4-heading">¶</a>h4 Heading</h4>
-<h5 id="h5-heading"><a class="header-anchor" href="#h5-heading">¶</a>h5 Heading</h5>
-<h6 id="h6-heading"><a class="header-anchor" href="#h6-heading">¶</a>h6 Heading</h6>
-<h2 id="horizontal-rule"><a class="header-anchor" href="#horizontal-rule">¶</a>Horizontal Rule</h2>
+<h2 id="h2-Heading-P"><a class="header-anchor" href="#h2-Heading-P">¶</a>h2 Heading :P</h2>
+<h3 id="h3-Heading"><a class="header-anchor" href="#h3-Heading">¶</a>h3 Heading</h3>
+<h4 id="h4-Heading"><a class="header-anchor" href="#h4-Heading">¶</a>h4 Heading</h4>
+<h5 id="h5-Heading"><a class="header-anchor" href="#h5-Heading">¶</a>h5 Heading</h5>
+<h6 id="h6-Heading"><a class="header-anchor" href="#h6-Heading">¶</a>h6 Heading</h6>
+<h2 id="Horizontal-Rule"><a class="header-anchor" href="#Horizontal-Rule">¶</a>Horizontal Rule</h2>
 <hr>
-<h2 id="horizontal-rule-ver2"><a class="header-anchor" href="#horizontal-rule-ver2">¶</a>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-ver2"><a class="header-anchor" href="#Horizontal-Rule-ver2">¶</a>Horizontal Rule</h2>
 <hr>
-<h2 id="horizontal-rule-ver3"><a class="header-anchor" href="#horizontal-rule-ver3">¶</a>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-ver3"><a class="header-anchor" href="#Horizontal-Rule-ver3">¶</a>Horizontal Rule</h2>
 <hr>
-<h2 id="typographic-replacements"><a class="header-anchor" href="#typographic-replacements">¶</a>Typographic replacements</h2>
+<h2 id="Typographic-replacements"><a class="header-anchor" href="#Typographic-replacements">¶</a>Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
 <p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
 <p>test.. test... test..... test?..... test!....</p>
 <p>!!!!!! ???? ,,  -- ---</p>
 <p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
-<h2 id="emphasis"><a class="header-anchor" href="#emphasis">¶</a>Emphasis</h2>
+<h2 id="Emphasis"><a class="header-anchor" href="#Emphasis">¶</a>Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
 <p><em>This is italic text</em></p>
 <p><em>This is italic text</em></p>
 <p><s>Strikethrough</s></p>
-<h2 id="blockquotes"><a class="header-anchor" href="#blockquotes">¶</a>Blockquotes</h2>
+<h2 id="Blockquotes"><a class="header-anchor" href="#Blockquotes">¶</a>Blockquotes</h2>
 <blockquote>
 <p>Blockquotes can also be nested...</p>
 <blockquote>
@@ -32,7 +32,7 @@
 </blockquote>
 </blockquote>
 </blockquote>
-<h2 id="lists"><a class="header-anchor" href="#lists">¶</a>Lists</h2>
+<h2 id="Lists"><a class="header-anchor" href="#Lists">¶</a>Lists</h2>
 <p>Unordered</p>
 <ul>
 <li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
@@ -59,7 +59,7 @@
 <li>Consectetur adipiscing elit</li>
 <li>Integer molestie lorem at massa</li>
 </ol>
-<h2 id="code"><a class="header-anchor" href="#code">¶</a>Code</h2>
+<h2 id="Code"><a class="header-anchor" href="#Code">¶</a>Code</h2>
 <p>Inline <code>code</code></p>
 <p>Indented code</p>
 <pre><code>// Some comments
@@ -77,7 +77,7 @@ line 3 of code
 
 console.log(foo(5));
 </code></pre>
-<h2 id="tables"><a class="header-anchor" href="#tables">¶</a>Tables</h2>
+<h2 id="Tables"><a class="header-anchor" href="#Tables">¶</a>Tables</h2>
 <table>
 <thead>
 <tr>
@@ -123,23 +123,23 @@ console.log(foo(5));
 </tr>
 </tbody>
 </table>
-<h2 id="links"><a class="header-anchor" href="#links">¶</a>Links</h2>
+<h2 id="Links"><a class="header-anchor" href="#Links">¶</a>Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
 <p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
-<h2 id="images"><a class="header-anchor" href="#images">¶</a>Images</h2>
+<h2 id="Images"><a class="header-anchor" href="#Images">¶</a>Images</h2>
 <p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
 <p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
-<h2 id="plugins"><a class="header-anchor" href="#plugins">¶</a>Plugins</h2>
+<h2 id="Plugins"><a class="header-anchor" href="#Plugins">¶</a>Plugins</h2>
 <p>The killer feature of <code>markdown-it</code> is very effective support of
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
-<h3 id="emojies"><a class="header-anchor" href="#emojies">¶</a><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
+<h3 id="Emojies"><a class="header-anchor" href="#Emojies">¶</a><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
 <p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>
 <p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>
 </blockquote>
 <p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
-<h3 id="subscipt-superscirpt"><a class="header-anchor" href="#subscipt-superscirpt">¶</a><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
+<h3 id="Subscipt-Superscirpt"><a class="header-anchor" href="#Subscipt-Superscirpt">¶</a><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
 <ul>
 <li>19^th^</li>
 <li>H~2~O</li>
@@ -148,7 +148,7 @@ console.log(foo(5));
 <p>++Inserted text++</p>
 <h3 id="mark"><a class="header-anchor" href="#mark">¶</a><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
 <p>==Marked text==</p>
-<h3 id="footnotes"><a class="header-anchor" href="#footnotes">¶</a><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
+<h3 id="Footnotes"><a class="header-anchor" href="#Footnotes">¶</a><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
 <p>Footnote 1 link[^first].</p>
 <p>Footnote 2 link[^second].</p>
 <p>Inline footnote^[Text of inline footnote] definition.</p>
@@ -157,7 +157,7 @@ console.log(foo(5));
 <pre><code>and multiple paragraphs.
 </code></pre>
 <p>[^second]: Footnote text.</p>
-<h3 id="definition-lists"><a class="header-anchor" href="#definition-lists">¶</a><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
+<h3 id="Definition-lists"><a class="header-anchor" href="#Definition-lists">¶</a><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <p>Term 1</p>
 <p>:   Definition 1
 with lazy continuation.</p>
@@ -173,11 +173,11 @@ Third paragraph of definition 2.
 <p>Term 2
 ~ Definition 2a
 ~ Definition 2b</p>
-<h3 id="abbreviations"><a class="header-anchor" href="#abbreviations">¶</a><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
+<h3 id="Abbreviations"><a class="header-anchor" href="#Abbreviations">¶</a><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
-<h3 id="custom-containers"><a class="header-anchor" href="#custom-containers">¶</a><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
+<h3 id="Custom-containers"><a class="header-anchor" href="#Custom-containers">¶</a><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning
 <em>here be dragons</em>
 :::</p>

--- a/test/index.js
+++ b/test/index.js
@@ -164,7 +164,7 @@ describe('Hexo Renderer Markdown-it', () => {
     result.should.equal(parsed_plugins);
   });
 
-  it('should render anchor-headers if they are defined', () => {
+  it('anchors - should render anchor-headers if they are defined', () => {
     const anchors_with_permalinks = fs.readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
     let ctx = {
       config: {
@@ -197,7 +197,7 @@ describe('Hexo Renderer Markdown-it', () => {
         }
       }
     };
-    const anchorsNoPerm = '<h1 id="this-is-an-h1-title">This is an H1 title</h1>\n<h1 id="this-is-an-h1-title-2">This is an H1 title</h1>\n';
+    const anchorsNoPerm = '<h1 id="This-is-an-H1-title">This is an H1 title</h1>\n<h1 id="This-is-an-H1-title-2">This is an H1 title</h1>\n';
     const anchorsNoPerm_parse = render.bind(ctx);
     const anchorsNoPerm_result = anchorsNoPerm_parse({
       text: '# This is an H1 title\n# This is an H1 title'
@@ -206,6 +206,24 @@ describe('Hexo Renderer Markdown-it', () => {
 
     anchorsNoPerm_result.should.equal(anchorsNoPerm);
     result.should.equal(anchors_with_permalinks);
+  });
 
+  it('anchors - should parse options correctly', () => {
+    const ctx = {
+      config: {
+        markdown: {
+          anchors: {
+            level: 2,
+            case: 1,
+            separator: '_'
+          }
+        }
+      }
+    };
+    const parse = render.bind(ctx);
+    const result = parse({
+      text: '## foo BAR'
+    });
+    result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: anchors retain case by default

Noticed while reviewing https://github.com/hexojs/hexo-renderer-markdown-it/pull/94, this plugin currently uses [sluggo](https://www.npmjs.com/package/sluggo) library. This PR replaces it with hexo-util [`slugize()`](https://github.com/hexojs/hexo-util#slugizestr-options) used in hexo and hexo-renderer-marked.

This shares similar goal with https://github.com/hexojs/hexo-renderer-markdown-it/pull/90 to bring consistency with hexo-renderer-marked. I think there'll be no more breaking change for [v4](https://github.com/hexojs/hexo-renderer-markdown-it/pull/91). Later PRs are more on feature parity (features that enabled by default in hexo-renderer-marked).