### PR TITLE
feat: permalinkSide

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ markdown:
   anchors:
     level: 2
     collisionSuffix: ''
-    permalink: false,
+    permalink: false
     permalinkClass: 'header-anchor'
+    permalinkSide: 'left'
     permalinkSymbol: '¶'
     case: 0
     separator: ''

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ hexo.config.markdown.anchors = Object.assign({
   collisionSuffix: '',
   permalink: false,
   permalinkClass: 'header-anchor',
+  permalinkSide: 'left',
   permalinkSymbol: '¶',
   case: 0,
   separator: ''

--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -4,13 +4,19 @@ const Token = require('markdown-it/lib/token');
 const { slugize } = require('hexo-util');
 
 const renderPermalink = function(slug, opts, tokens, idx) {
-  return tokens[idx + 1].children.unshift(Object.assign(new Token('link_open', 'a', 1), {
+  const permalink = [Object.assign(new Token('link_open', 'a', 1), {
     attrs: [['class', opts.permalinkClass], ['href', '#' + slug]]
   }), Object.assign(new Token('text', '', 0), {
     content: opts.permalinkSymbol
   }), new Token('link_close', 'a', -1), Object.assign(new Token('text', '', 0), {
     content: ''
-  }));
+  })];
+
+  if (opts.permalinkSide === 'right') {
+    return tokens[idx + 1].children.push(...permalink);
+  }
+
+  return tokens[idx + 1].children.unshift(...permalink);
 };
 
 const anchor = function(md, opts) {

--- a/test/index.js
+++ b/test/index.js
@@ -226,4 +226,35 @@ describe('Hexo Renderer Markdown-it', () => {
     });
     result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
   });
+
+  describe('anchors - permalinkSide', () => {
+    const ctx = {
+      config: {
+        markdown: {
+          anchors: {
+            level: 2,
+            permalink: true,
+            permalinkClass: 'anchor',
+            permalinkSide: 'left',
+            permalinkSymbol: '#'
+          }
+        }
+      }
+    };
+    const parse = render.bind(ctx);
+    const text = '## foo';
+
+    it('left', () => {
+      const result = parse({ text });
+
+      result.should.equal('<h2 id="foo"><a class="anchor" href="#foo">#</a>foo</h2>\n');
+    });
+
+    it('right', () => {
+      ctx.config.markdown.anchors.permalinkSide = 'right';
+      const result = parse({ text });
+
+      result.should.equal('<h2 id="foo">foo<a class="anchor" href="#foo">#</a></h2>\n');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #101

How to use:

``` yml
markdown:
  anchors:
    permalink: true
    permalinkSide: 'right'
    permalinkSymbol: '#'
```

`#` should appear on the right side of each heading, instead of the default left.