### PR TITLE
feat: support preset and render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Follow the [installation guide](https://github.com/hexojs/hexo-renderer-markdown
 
 ``` yml
 markdown:
+  preset: 'default'
   render:
     html: true
     xhtmlOut: false

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 'use strict';
 
 hexo.config.markdown = Object.assign({
+  preset: 'default',
   render: {},
   anchors: {}
 }, hexo.config.markdown);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -2,14 +2,21 @@
 
 module.exports = function(data, options) {
   const MdIt = require('markdown-it');
-  const cfg = this.config.markdown;
-  const opt = cfg ? cfg : 'default';
-  let parser = opt === 'default' || opt === 'commonmark' || opt === 'zero'
-    ? new MdIt(opt)
-    : new MdIt(opt.render);
+  let { markdown } = this.config;
 
-  if (opt.plugins) {
-    parser = opt.plugins.reduce((parser, pugs) => {
+  // Temporary backward compatibility
+  if (typeof markdown === 'string') {
+    markdown = {
+      preset: markdown
+    };
+    this.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
+  }
+
+  const { preset, render, plugins, anchors } = markdown;
+  let parser = new MdIt(preset, render);
+
+  if (plugins) {
+    parser = plugins.reduce((parser, pugs) => {
       if (pugs instanceof Object && pugs.name) {
         return parser.use(require(pugs.name), pugs.options);
       }
@@ -18,8 +25,8 @@ module.exports = function(data, options) {
     }, parser);
   }
 
-  if (opt.anchors) {
-    parser = parser.use(require('./anchors'), opt.anchors);
+  if (anchors) {
+    parser = parser.use(require('./anchors'), anchors);
   }
 
   this.execFilterSync('markdown-it:renderer', parser, { context: this });

--- a/test/fixtures/outputs/anchors.html
+++ b/test/fixtures/outputs/anchors.html
@@ -12,10 +12,10 @@
 <hr>
 <h2 id="Typographic-replacements"><a class="header-anchor" href="#Typographic-replacements">¶</a>Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
-<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
-<p>test.. test... test..... test?..... test!....</p>
-<p>!!!!!! ???? ,,  -- ---</p>
-<p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
+<p>© © ® ® ™ ™ § § ±</p>
+<p>test… test… test… test?.. test!..</p>
+<p>!!! ??? ,  – —</p>
+<p>“Smartypants, double quotes” and ‘single quotes’</p>
 <h2 id="Emphasis"><a class="header-anchor" href="#Emphasis">¶</a>Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
@@ -24,11 +24,11 @@
 <p><s>Strikethrough</s></p>
 <h2 id="Blockquotes"><a class="header-anchor" href="#Blockquotes">¶</a>Blockquotes</h2>
 <blockquote>
-<p>Blockquotes can also be nested...</p>
+<p>Blockquotes can also be nested…</p>
 <blockquote>
-<p>...by using additional greater-than signs right next to each other...</p>
+<p>…by using additional greater-than signs right next to each other…</p>
 <blockquote>
-<p>...or with spaces between arrows.</p>
+<p>…or with spaces between arrows.</p>
 </blockquote>
 </blockquote>
 </blockquote>
@@ -67,7 +67,7 @@ line 1 of code
 line 2 of code
 line 3 of code
 </code></pre>
-<p>Block code &quot;fences&quot;</p>
+<p>Block code “fences”</p>
 <pre><code>Sample text here...
 </code></pre>
 <p>Syntax highlighting</p>
@@ -125,13 +125,13 @@ console.log(foo(5));
 </table>
 <h2 id="Links"><a class="header-anchor" href="#Links">¶</a>Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
-<p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
+<p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a> (enable linkify to see)</p>
 <h2 id="Images"><a class="header-anchor" href="#Images">¶</a>Images</h2>
-<p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion"><br>
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
 <p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
 <h2 id="Plugins"><a class="header-anchor" href="#Plugins">¶</a>Plugins</h2>
-<p>The killer feature of <code>markdown-it</code> is very effective support of
+<p>The killer feature of <code>markdown-it</code> is very effective support of<br>
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
 <h3 id="Emojies"><a class="header-anchor" href="#Emojies">¶</a><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
@@ -159,7 +159,7 @@ console.log(foo(5));
 <p>[^second]: Footnote text.</p>
 <h3 id="Definition-lists"><a class="header-anchor" href="#Definition-lists">¶</a><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <p>Term 1</p>
-<p>:   Definition 1
+<p>:   Definition 1<br>
 with lazy continuation.</p>
 <p>Term 2 with <em>inline markup</em></p>
 <p>:   Definition 2</p>
@@ -168,16 +168,16 @@ with lazy continuation.</p>
 Third paragraph of definition 2.
 </code></pre>
 <p><em>Compact style:</em></p>
-<p>Term 1
+<p>Term 1<br>
 ~ Definition 1</p>
-<p>Term 2
-~ Definition 2a
+<p>Term 2<br>
+~ Definition 2a<br>
 ~ Definition 2b</p>
 <h3 id="Abbreviations"><a class="header-anchor" href="#Abbreviations">¶</a><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is HTML abbreviation example.</p>
-<p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
+<p>It converts “HTML”, but keep intact partial entries like “xxxHTMLyyy” and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
 <h3 id="Custom-containers"><a class="header-anchor" href="#Custom-containers">¶</a><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
-<p>::: warning
-<em>here be dragons</em>
+<p>::: warning<br>
+<em>here be dragons</em><br>
 :::</p>

--- a/test/fixtures/outputs/commonmark-deprecated.html
+++ b/test/fixtures/outputs/commonmark-deprecated.html
@@ -1,28 +1,28 @@
 <h1>h1 Heading em português</h1>
-<h2 id="h2-Heading-P">h2 Heading :P</h2>
-<h3 id="h3-Heading">h3 Heading</h3>
-<h4 id="h4-Heading">h4 Heading</h4>
-<h5 id="h5-Heading">h5 Heading</h5>
-<h6 id="h6-Heading">h6 Heading</h6>
-<h2 id="Horizontal-Rule">Horizontal Rule</h2>
-<hr>
-<h2 id="Horizontal-Rule-2">Horizontal Rule</h2>
-<hr>
-<h2 id="Horizontal-Rule-3">Horizontal Rule</h2>
-<hr>
-<h2 id="Typographic-replacements">Typographic replacements</h2>
+<h2>h2 Heading :P</h2>
+<h3>h3 Heading</h3>
+<h4>h4 Heading</h4>
+<h5>h5 Heading</h5>
+<h6>h6 Heading</h6>
+<h2>Horizontal Rule</h2>
+<hr />
+<h2>Horizontal Rule</h2>
+<hr />
+<h2>Horizontal Rule</h2>
+<hr />
+<h2>Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
 <p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
 <p>test.. test... test..... test?..... test!....</p>
 <p>!!!!!! ???? ,,  -- ---</p>
 <p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
-<h2 id="Emphasis">Emphasis</h2>
+<h2>Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
 <p><em>This is italic text</em></p>
 <p><em>This is italic text</em></p>
 <p>~~Strikethrough~~</p>
-<h2 id="Blockquotes">Blockquotes</h2>
+<h2>Blockquotes</h2>
 <blockquote>
 <p>Blockquotes can also be nested...</p>
 <blockquote>
@@ -32,7 +32,7 @@
 </blockquote>
 </blockquote>
 </blockquote>
-<h2 id="Lists">Lists</h2>
+<h2>Lists</h2>
 <p>Unordered</p>
 <ul>
 <li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
@@ -59,7 +59,7 @@
 <li>Consectetur adipiscing elit</li>
 <li>Integer molestie lorem at massa</li>
 </ol>
-<h2 id="Code">Code</h2>
+<h2>Code</h2>
 <p>Inline <code>code</code></p>
 <p>Indented code</p>
 <pre><code>// Some comments
@@ -77,44 +77,44 @@ line 3 of code
 
 console.log(foo(5));
 </code></pre>
-<h2 id="Tables">Tables</h2>
-<p>| Option | Description |<br>
-| ------ | ----------- |<br>
-| data   | path to data files to supply the data that will be passed into templates. |<br>
-| engine | engine to be used for processing templates. Handlebars is the default. |<br>
+<h2>Tables</h2>
+<p>| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |</p>
 <p>Right aligned columns</p>
-<p>| Option | Description |<br>
-| ------:| -----------:|<br>
-| data   | path to data files to supply the data that will be passed into templates. |<br>
-| engine | engine to be used for processing templates. Handlebars is the default. |<br>
+<p>| Option | Description |
+| ------:| -----------:|
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
 | ext    | extension to be used for dest files. |</p>
-<h2 id="Links">Links</h2>
+<h2>Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
 <p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
-<h2 id="Images">Images</h2>
-<p><img src="https://octodex.github.com/images/minion.png" alt="Minion"><br>
-<img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
-<p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
-<h2 id="Plugins">Plugins</h2>
-<p>The killer feature of <code>markdown-it</code> is very effective support of<br>
+<h2>Images</h2>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion" />
+<img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" /></p>
+<p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat" /></p>
+<h2>Plugins</h2>
+<p>The killer feature of <code>markdown-it</code> is very effective support of
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
-<h3 id="Emojies"><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
 <p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>
 <p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>
 </blockquote>
 <p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
-<h3 id="Subscipt-Superscirpt"><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
 <ul>
 <li>19^th^</li>
 <li>H~2~O</li>
 </ul>
-<h3 id="ins"><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
 <p>++Inserted text++</p>
-<h3 id="mark"><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
 <p>==Marked text==</p>
-<h3 id="Footnotes"><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
 <p>Footnote 1 link[^first].</p>
 <p>Footnote 2 link[^second].</p>
 <p>Inline footnote^[Text of inline footnote] definition.</p>
@@ -123,9 +123,9 @@ console.log(foo(5));
 <pre><code>and multiple paragraphs.
 </code></pre>
 <p>[^second]: Footnote text.</p>
-<h3 id="Definition-lists"><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <p>Term 1</p>
-<p>:   Definition 1<br>
+<p>:   Definition 1
 with lazy continuation.</p>
 <p>Term 2 with <em>inline markup</em></p>
 <p>:   Definition 2</p>
@@ -134,16 +134,16 @@ with lazy continuation.</p>
 Third paragraph of definition 2.
 </code></pre>
 <p><em>Compact style:</em></p>
-<p>Term 1<br>
+<p>Term 1
 ~ Definition 1</p>
-<p>Term 2<br>
-~ Definition 2a<br>
+<p>Term 2
+~ Definition 2a
 ~ Definition 2b</p>
-<h3 id="Abbreviations"><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
+<h3><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is HTML abbreviation example.</p>
 <p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
-<h3 id="Custom-containers"><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
-<p>::: warning<br>
-<em>here be dragons</em><br>
+<h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
+<p>::: warning
+<em>here be dragons</em>
 :::</p>

--- a/test/fixtures/outputs/custom.html
+++ b/test/fixtures/outputs/custom.html
@@ -1,28 +1,28 @@
 <h1>h1 Heading em português</h1>
-<h2>h2 Heading :P</h2>
-<h3>h3 Heading</h3>
-<h4>h4 Heading</h4>
-<h5>h5 Heading</h5>
-<h6>h6 Heading</h6>
-<h2>Horizontal Rule</h2>
+<h2 id="h2-Heading-P">h2 Heading :P</h2>
+<h3 id="h3-Heading">h3 Heading</h3>
+<h4 id="h4-Heading">h4 Heading</h4>
+<h5 id="h5-Heading">h5 Heading</h5>
+<h6 id="h6-Heading">h6 Heading</h6>
+<h2 id="Horizontal-Rule">Horizontal Rule</h2>
 <hr />
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-2">Horizontal Rule</h2>
 <hr />
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-3">Horizontal Rule</h2>
 <hr />
-<h2>Typographic replacements</h2>
+<h2 id="Typographic-replacements">Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
 <p>© © ® ® ™ ™ § § ±</p>
 <p>test… test… test… test?.. test!..</p>
 <p>!!! ??? ,  – —</p>
 <p>«Smartypants, double quotes» and “single quotes”</p>
-<h2>Emphasis</h2>
+<h2 id="Emphasis">Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
 <p><em>This is italic text</em></p>
 <p><em>This is italic text</em></p>
 <p><s>Strikethrough</s></p>
-<h2>Blockquotes</h2>
+<h2 id="Blockquotes">Blockquotes</h2>
 <blockquote>
 <p>Blockquotes can also be nested…</p>
 <blockquote>
@@ -32,7 +32,7 @@
 </blockquote>
 </blockquote>
 </blockquote>
-<h2>Lists</h2>
+<h2 id="Lists">Lists</h2>
 <p>Unordered</p>
 <ul>
 <li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
@@ -59,7 +59,7 @@
 <li>Consectetur adipiscing elit</li>
 <li>Integer molestie lorem at massa</li>
 </ol>
-<h2>Code</h2>
+<h2 id="Code">Code</h2>
 <p>Inline <code>code</code></p>
 <p>Indented code</p>
 <pre><code>// Some comments
@@ -77,7 +77,7 @@ line 3 of code
 
 console.log(foo(5));
 </code></pre>
-<h2>Tables</h2>
+<h2 id="Tables">Tables</h2>
 <table>
 <thead>
 <tr>
@@ -123,32 +123,32 @@ console.log(foo(5));
 </tr>
 </tbody>
 </table>
-<h2>Links</h2>
+<h2 id="Links">Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
 <p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a> (enable linkify to see)</p>
-<h2>Images</h2>
+<h2 id="Images">Images</h2>
 <p><img src="https://octodex.github.com/images/minion.png" alt="Minion" /><br />
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat" /></p>
 <p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat" /></p>
-<h2>Plugins</h2>
+<h2 id="Plugins">Plugins</h2>
 <p>The killer feature of <code>markdown-it</code> is very effective support of<br />
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
+<h3 id="Emojies"><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
 <p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>
 <p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>
 </blockquote>
 <p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
+<h3 id="Subscipt-Superscirpt"><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
 <ul>
 <li>19^th^</li>
 <li>H~2~O</li>
 </ul>
-<h3><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
+<h3 id="ins"><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
 <p>++Inserted text++</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
+<h3 id="mark"><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
 <p>==Marked text==</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
+<h3 id="Footnotes"><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
 <p>Footnote 1 link[^first].</p>
 <p>Footnote 2 link[^second].</p>
 <p>Inline footnote^[Text of inline footnote] definition.</p>
@@ -157,7 +157,7 @@ console.log(foo(5));
 <pre><code>and multiple paragraphs.
 </code></pre>
 <p>[^second]: Footnote text.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
+<h3 id="Definition-lists"><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <p>Term 1</p>
 <p>:   Definition 1<br />
 with lazy continuation.</p>
@@ -173,11 +173,11 @@ Third paragraph of definition 2.
 <p>Term 2<br />
 ~ Definition 2a<br />
 ~ Definition 2b</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
+<h3 id="Abbreviations"><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is HTML abbreviation example.</p>
 <p>It converts «HTML», but keep intact partial entries like «xxxHTMLyyy» and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
+<h3 id="Custom-containers"><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
 <p>::: warning<br />
 <em>here be dragons</em><br />
 :::</p>

--- a/test/fixtures/outputs/default.html
+++ b/test/fixtures/outputs/default.html
@@ -1,38 +1,38 @@
 <h1>h1 Heading em português</h1>
-<h2>h2 Heading :P</h2>
-<h3>h3 Heading</h3>
-<h4>h4 Heading</h4>
-<h5>h5 Heading</h5>
-<h6>h6 Heading</h6>
-<h2>Horizontal Rule</h2>
+<h2 id="h2-Heading-P">h2 Heading :P</h2>
+<h3 id="h3-Heading">h3 Heading</h3>
+<h4 id="h4-Heading">h4 Heading</h4>
+<h5 id="h5-Heading">h5 Heading</h5>
+<h6 id="h6-Heading">h6 Heading</h6>
+<h2 id="Horizontal-Rule">Horizontal Rule</h2>
 <hr>
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-2">Horizontal Rule</h2>
 <hr>
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-3">Horizontal Rule</h2>
 <hr>
-<h2>Typographic replacements</h2>
+<h2 id="Typographic-replacements">Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
-<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
-<p>test.. test... test..... test?..... test!....</p>
-<p>!!!!!! ???? ,,  -- ---</p>
-<p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
-<h2>Emphasis</h2>
+<p>© © ® ® ™ ™ § § ±</p>
+<p>test… test… test… test?.. test!..</p>
+<p>!!! ??? ,  – —</p>
+<p>“Smartypants, double quotes” and ‘single quotes’</p>
+<h2 id="Emphasis">Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
 <p><em>This is italic text</em></p>
 <p><em>This is italic text</em></p>
 <p><s>Strikethrough</s></p>
-<h2>Blockquotes</h2>
+<h2 id="Blockquotes">Blockquotes</h2>
 <blockquote>
-<p>Blockquotes can also be nested...</p>
+<p>Blockquotes can also be nested…</p>
 <blockquote>
-<p>...by using additional greater-than signs right next to each other...</p>
+<p>…by using additional greater-than signs right next to each other…</p>
 <blockquote>
-<p>...or with spaces between arrows.</p>
+<p>…or with spaces between arrows.</p>
 </blockquote>
 </blockquote>
 </blockquote>
-<h2>Lists</h2>
+<h2 id="Lists">Lists</h2>
 <p>Unordered</p>
 <ul>
 <li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
@@ -59,7 +59,7 @@
 <li>Consectetur adipiscing elit</li>
 <li>Integer molestie lorem at massa</li>
 </ol>
-<h2>Code</h2>
+<h2 id="Code">Code</h2>
 <p>Inline <code>code</code></p>
 <p>Indented code</p>
 <pre><code>// Some comments
@@ -67,7 +67,7 @@ line 1 of code
 line 2 of code
 line 3 of code
 </code></pre>
-<p>Block code &quot;fences&quot;</p>
+<p>Block code “fences”</p>
 <pre><code>Sample text here...
 </code></pre>
 <p>Syntax highlighting</p>
@@ -77,7 +77,7 @@ line 3 of code
 
 console.log(foo(5));
 </code></pre>
-<h2>Tables</h2>
+<h2 id="Tables">Tables</h2>
 <table>
 <thead>
 <tr>
@@ -123,32 +123,32 @@ console.log(foo(5));
 </tr>
 </tbody>
 </table>
-<h2>Links</h2>
+<h2 id="Links">Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
-<p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
-<h2>Images</h2>
-<p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
+<p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a> (enable linkify to see)</p>
+<h2 id="Images">Images</h2>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion"><br>
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
 <p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
-<h2>Plugins</h2>
-<p>The killer feature of <code>markdown-it</code> is very effective support of
+<h2 id="Plugins">Plugins</h2>
+<p>The killer feature of <code>markdown-it</code> is very effective support of<br>
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
+<h3 id="Emojies"><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
 <p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>
 <p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>
 </blockquote>
 <p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
+<h3 id="Subscipt-Superscirpt"><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
 <ul>
 <li>19^th^</li>
 <li>H~2~O</li>
 </ul>
-<h3><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
+<h3 id="ins"><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
 <p>++Inserted text++</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
+<h3 id="mark"><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
 <p>==Marked text==</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
+<h3 id="Footnotes"><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
 <p>Footnote 1 link[^first].</p>
 <p>Footnote 2 link[^second].</p>
 <p>Inline footnote^[Text of inline footnote] definition.</p>
@@ -157,9 +157,9 @@ console.log(foo(5));
 <pre><code>and multiple paragraphs.
 </code></pre>
 <p>[^second]: Footnote text.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
+<h3 id="Definition-lists"><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <p>Term 1</p>
-<p>:   Definition 1
+<p>:   Definition 1<br>
 with lazy continuation.</p>
 <p>Term 2 with <em>inline markup</em></p>
 <p>:   Definition 2</p>
@@ -168,16 +168,16 @@ with lazy continuation.</p>
 Third paragraph of definition 2.
 </code></pre>
 <p><em>Compact style:</em></p>
-<p>Term 1
+<p>Term 1<br>
 ~ Definition 1</p>
-<p>Term 2
-~ Definition 2a
+<p>Term 2<br>
+~ Definition 2a<br>
 ~ Definition 2b</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
+<h3 id="Abbreviations"><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is HTML abbreviation example.</p>
-<p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
+<p>It converts “HTML”, but keep intact partial entries like “xxxHTMLyyy” and so on.</p>
 <p>*[HTML]: Hyper Text Markup Language</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
-<p>::: warning
-<em>here be dragons</em>
+<h3 id="Custom-containers"><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
+<p>::: warning<br>
+<em>here be dragons</em><br>
 :::</p>

--- a/test/fixtures/outputs/plugins.html
+++ b/test/fixtures/outputs/plugins.html
@@ -1,38 +1,38 @@
 <h1>h1 Heading em português</h1>
-<h2>h2 Heading 😛</h2>
-<h3>h3 Heading</h3>
-<h4>h4 Heading</h4>
-<h5>h5 Heading</h5>
-<h6>h6 Heading</h6>
-<h2>Horizontal Rule</h2>
+<h2 id="h2-Heading-😛">h2 Heading 😛</h2>
+<h3 id="h3-Heading">h3 Heading</h3>
+<h4 id="h4-Heading">h4 Heading</h4>
+<h5 id="h5-Heading">h5 Heading</h5>
+<h6 id="h6-Heading">h6 Heading</h6>
+<h2 id="Horizontal-Rule">Horizontal Rule</h2>
 <hr>
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-2">Horizontal Rule</h2>
 <hr>
-<h2>Horizontal Rule</h2>
+<h2 id="Horizontal-Rule-3">Horizontal Rule</h2>
 <hr>
-<h2>Typographic replacements</h2>
+<h2 id="Typographic-replacements">Typographic replacements</h2>
 <p>Enable typographer option to see result.</p>
-<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
-<p>test.. test... test..... test?..... test!....</p>
-<p>!!!!!! ???? ,,  -- ---</p>
-<p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
-<h2>Emphasis</h2>
+<p>© © ® ® ™ ™ § § ±</p>
+<p>test… test… test… test?.. test!..</p>
+<p>!!! ??? ,  – —</p>
+<p>“Smartypants, double quotes” and ‘single quotes’</p>
+<h2 id="Emphasis">Emphasis</h2>
 <p><strong>This is bold text</strong></p>
 <p><strong>This is bold text</strong></p>
 <p><em>This is italic text</em></p>
 <p><em>This is italic text</em></p>
 <p><s>Strikethrough</s></p>
-<h2>Blockquotes</h2>
+<h2 id="Blockquotes">Blockquotes</h2>
 <blockquote>
-<p>Blockquotes can also be nested...</p>
+<p>Blockquotes can also be nested…</p>
 <blockquote>
-<p>...by using additional greater-than signs right next to each other...</p>
+<p>…by using additional greater-than signs right next to each other…</p>
 <blockquote>
-<p>...or with spaces between arrows.</p>
+<p>…or with spaces between arrows.</p>
 </blockquote>
 </blockquote>
 </blockquote>
-<h2>Lists</h2>
+<h2 id="Lists">Lists</h2>
 <p>Unordered</p>
 <ul>
 <li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
@@ -59,7 +59,7 @@
 <li>Consectetur adipiscing elit</li>
 <li>Integer molestie lorem at massa</li>
 </ol>
-<h2>Code</h2>
+<h2 id="Code">Code</h2>
 <p>Inline <code>code</code></p>
 <p>Indented code</p>
 <pre><code>// Some comments
@@ -67,7 +67,7 @@ line 1 of code
 line 2 of code
 line 3 of code
 </code></pre>
-<p>Block code &quot;fences&quot;</p>
+<p>Block code “fences”</p>
 <pre><code>Sample text here...
 </code></pre>
 <p>Syntax highlighting</p>
@@ -77,7 +77,7 @@ line 3 of code
 
 console.log(foo(5));
 </code></pre>
-<h2>Tables</h2>
+<h2 id="Tables">Tables</h2>
 <table>
 <thead>
 <tr>
@@ -123,41 +123,41 @@ console.log(foo(5));
 </tr>
 </tbody>
 </table>
-<h2>Links</h2>
+<h2 id="Links">Links</h2>
 <p><a href="http://dev.nodeca.com">link text</a></p>
-<p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
-<h2>Images</h2>
-<p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
+<p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a> (enable linkify to see)</p>
+<h2 id="Images">Images</h2>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion"><br>
 <img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
 <p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
-<h2>Plugins</h2>
-<p>The killer feature of <code>markdown-it</code> is very effective support of
+<h2 id="Plugins">Plugins</h2>
+<p>The killer feature of <code>markdown-it</code> is very effective support of<br>
 <a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
+<h3 id="Emojies"><a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></h3>
 <blockquote>
 <p>Classic markup: 😉 :crush: 😢 :tear: 😆 😋</p>
 <p>Shortcuts (emoticons): 😃 😦 😎 😉</p>
 </blockquote>
 <p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
+<h3 id="Subscipt-Superscirpt"><a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></h3>
 <ul>
 <li>19<sup>th</sup></li>
 <li>H<sub>2</sub>O</li>
 </ul>
-<h3><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
+<h3 id="ins"><a href="https://github.com/markdown-it/markdown-it-ins">&lt;ins&gt;</a></h3>
 <p><ins>Inserted text</ins></p>
-<h3><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
+<h3 id="mark"><a href="https://github.com/markdown-it/markdown-it-mark">&lt;mark&gt;</a></h3>
 <p><mark>Marked text</mark></p>
-<h3><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
+<h3 id="Footnotes"><a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></h3>
 <p>Footnote 1 link<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>.</p>
 <p>Footnote 2 link<sup class="footnote-ref"><a href="#fn2" id="fnref2">[2]</a></sup>.</p>
 <p>Inline footnote<sup class="footnote-ref"><a href="#fn3" id="fnref3">[3]</a></sup> definition.</p>
 <p>Duplicated footnote reference<sup class="footnote-ref"><a href="#fn2" id="fnref2:1">[2:1]</a></sup>.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
+<h3 id="Definition-lists"><a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></h3>
 <dl>
 <dt>Term 1</dt>
 <dd>
-<p>Definition 1
+<p>Definition 1<br>
 with lazy continuation.</p>
 </dd>
 <dt>Term 2 with <em>inline markup</em></dt>
@@ -176,12 +176,12 @@ with lazy continuation.</p>
 <dd>Definition 2a</dd>
 <dd>Definition 2b</dd>
 </dl>
-<h3><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
+<h3 id="Abbreviations"><a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></h3>
 <p>This is <abbr title="Hyper Text Markup Language">HTML</abbr> abbreviation example.</p>
-<p>It converts &quot;<abbr title="Hyper Text Markup Language">HTML</abbr>&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
-<h3><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
-<p>::: warning
-<em>here be dragons</em>
+<p>It converts “<abbr title="Hyper Text Markup Language">HTML</abbr>”, but keep intact partial entries like “xxxHTMLyyy” and so on.</p>
+<h3 id="Custom-containers"><a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></h3>
+<p>::: warning<br>
+<em>here be dragons</em><br>
 :::</p>
 <hr class="footnotes-sep">
 <section class="footnotes">

--- a/test/index.js
+++ b/test/index.js
@@ -9,24 +9,36 @@ const Hexo = require('hexo');
 describe('Hexo Renderer Markdown-it', () => {
   const hexo = new Hexo(__dirname, { silent: true });
   const parse = render.bind(hexo);
-  const defaultCfg = JSON.parse(JSON.stringify(hexo.config));
+  const defaultCfg = JSON.parse(JSON.stringify(Object.assign(hexo.config, {
+    markdown: {
+      preset: 'default',
+      render: {
+        html: true,
+        xhtmlOut: false,
+        breaks: true,
+        linkify: true,
+        typographer: true,
+        quotes: '“”‘’'
+      },
+      anchors: {
+        level: 2,
+        collisionSuffix: '',
+        permalink: false,
+        permalinkClass: 'header-anchor',
+        permalinkSide: 'left',
+        permalinkSymbol: '¶',
+        case: 0,
+        separator: ''
+      }
+    }
+  })));
 
   beforeEach(() => {
     hexo.config = JSON.parse(JSON.stringify(defaultCfg));
   });
 
-  it('should render GFM if no config provided', () => {
-    hexo.config = {};
-
-    const parsed_without_config = fs.readFileSync('./test/fixtures/outputs/default.html', 'utf8');
-    const result = parse({
-      text: source
-    });
-    result.should.equal(parsed_without_config);
-  });
-
   it('should render CommonMark if config is \'commonmark\'', () => {
-    hexo.config.markdown = 'commonmark';
+    hexo.config.markdown.preset = 'commonmark';
 
     const parsed_commonmark = fs.readFileSync('./test/fixtures/outputs/commonmark.html', 'utf8');
     const result = parse({
@@ -35,8 +47,19 @@ describe('Hexo Renderer Markdown-it', () => {
     result.should.equal(parsed_commonmark);
   });
 
+  // Deprecated
+  it('should handle deprecated config', () => {
+    hexo.config.markdown = 'commonmark';
+
+    const parsed_commonmark = fs.readFileSync('./test/fixtures/outputs/commonmark-deprecated.html', 'utf8');
+    const result = parse({
+      text: source
+    });
+    result.should.equal(parsed_commonmark);
+  });
+
   it('should render a limited subset of Markdown if using \'zero\'', () => {
-    hexo.config.markdown = 'zero';
+    hexo.config.markdown.preset = 'zero';
 
     const parsed_zero = fs.readFileSync('./test/fixtures/outputs/zero.html', 'utf8');
     const result = parse({
@@ -46,7 +69,7 @@ describe('Hexo Renderer Markdown-it', () => {
   });
 
   it('should render something very close to GFM with \'default\'', () => {
-    hexo.config.markdown = 'default';
+    hexo.config.markdown.preset = 'default';
 
     const parsed_gfm = fs.readFileSync('./test/fixtures/outputs/default.html', 'utf8');
     const result = parse({
@@ -56,16 +79,14 @@ describe('Hexo Renderer Markdown-it', () => {
   });
 
   it('should handle a custom configuration', () => {
-    hexo.config.markdown = {
-      render: {
-        html: false,
-        xhtmlOut: true,
-        breaks: true,
-        langPrefix: '',
-        linkify: true,
-        typographer: true,
-        quotes: '«»“”'
-      }
+    hexo.config.markdown.render = {
+      html: false,
+      xhtmlOut: true,
+      breaks: true,
+      langPrefix: '',
+      linkify: true,
+      typographer: true,
+      quotes: '«»“”'
     };
 
     const parsed_custom = fs.readFileSync('./test/fixtures/outputs/custom.html', 'utf8');
@@ -77,60 +98,17 @@ describe('Hexo Renderer Markdown-it', () => {
   });
 
   it('should render plugins if they are defined', () => {
-    hexo.config.markdown = {
-      render: {
-        html: false,
-        xhtmlOut: false,
-        breaks: false,
-        langPrefix: 'language-',
-        linkify: false,
-        typographer: false,
-        quotes: '«»“”'
-      },
-      plugins: [
-        'markdown-it-abbr',
-        'markdown-it-container',
-        'markdown-it-deflist',
-        'markdown-it-emoji',
-        'markdown-it-footnote',
-        'markdown-it-ins',
-        'markdown-it-mark',
-        'markdown-it-sub',
-        'markdown-it-sup'
-      ]
-    };
-
-    const parsed_plugins = fs.readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
-    const source = fs.readFileSync('./test/fixtures/markdownit.md', 'utf8');
-    const result = parse({
-      text: source
-    });
-    result.should.equal(parsed_plugins);
-  });
-
-  it('should render a plugin defined as an object', () => {
-    hexo.config.markdown = {
-      render: {
-        html: false,
-        xhtmlOut: false,
-        breaks: false,
-        langPrefix: 'language-',
-        linkify: false,
-        typographer: false,
-        quotes: '«»“”'
-      },
-      plugins: [
-        'markdown-it-abbr',
-        'markdown-it-container',
-        'markdown-it-deflist',
-        'markdown-it-emoji',
-        'markdown-it-footnote',
-        'markdown-it-ins',
-        'markdown-it-mark',
-        'markdown-it-sub',
-        'markdown-it-sup'
-      ]
-    };
+    hexo.config.markdown.plugins = [
+      'markdown-it-abbr',
+      'markdown-it-container',
+      'markdown-it-deflist',
+      'markdown-it-emoji',
+      'markdown-it-footnote',
+      'markdown-it-ins',
+      'markdown-it-mark',
+      'markdown-it-sub',
+      'markdown-it-sup'
+    ];
 
     const parsed_plugins = fs.readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
     const source = fs.readFileSync('./test/fixtures/markdownit.md', 'utf8');
@@ -141,28 +119,24 @@ describe('Hexo Renderer Markdown-it', () => {
   });
 
   it('anchors - should render anchor-headers if they are defined', () => {
-    hexo.config.markdown = {
-      anchors: {
-        level: 2,
-        collisionSuffix: 'ver',
-        permalink: true,
-        permalinkClass: 'header-anchor',
-        permalinkSymbol: '¶'
-      }
+    hexo.config.markdown.anchors = {
+      level: 2,
+      collisionSuffix: 'ver',
+      permalink: true,
+      permalinkClass: 'header-anchor',
+      permalinkSymbol: '¶'
     };
     const anchors_with_permalinks = fs.readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
     const result = parse({
       text: source
     });
 
-    hexo.config.markdown = {
-      anchors: {
-        level: 1,
-        collisionSuffix: '',
-        permalink: false,
-        permalinkClass: 'header-anchor',
-        permalinkSymbol: '¶'
-      }
+    hexo.config.markdown.anchors = {
+      level: 1,
+      collisionSuffix: '',
+      permalink: false,
+      permalinkClass: 'header-anchor',
+      permalinkSymbol: '¶'
     };
     const anchorsNoPerm = '<h1 id="This-is-an-H1-title">This is an H1 title</h1>\n<h1 id="This-is-an-H1-title-2">This is an H1 title</h1>\n';
     const anchorsNoPerm_parse = render.bind(hexo);
@@ -175,12 +149,10 @@ describe('Hexo Renderer Markdown-it', () => {
   });
 
   it('anchors - should parse options correctly', () => {
-    hexo.config.markdown = {
-      anchors: {
-        level: 2,
-        case: 1,
-        separator: '_'
-      }
+    hexo.config.markdown.anchors = {
+      level: 2,
+      case: 1,
+      separator: '_'
     };
 
     const result = parse({
@@ -215,14 +187,12 @@ describe('Hexo Renderer Markdown-it', () => {
     const text = '## foo';
 
     it('left', () => {
-      hexo.config.markdown = {
-        anchors: {
-          level: 2,
-          permalink: true,
-          permalinkClass: 'anchor',
-          permalinkSide: 'left',
-          permalinkSymbol: '#'
-        }
+      hexo.config.markdown.anchors = {
+        level: 2,
+        permalink: true,
+        permalinkClass: 'anchor',
+        permalinkSide: 'left',
+        permalinkSymbol: '#'
       };
       const result = parse({ text });
 
@@ -230,14 +200,12 @@ describe('Hexo Renderer Markdown-it', () => {
     });
 
     it('right', () => {
-      hexo.config.markdown = {
-        anchors: {
-          level: 2,
-          permalink: true,
-          permalinkClass: 'anchor',
-          permalinkSide: 'right',
-          permalinkSymbol: '#'
-        }
+      hexo.config.markdown.anchors = {
+        level: 2,
+        permalink: true,
+        permalinkClass: 'anchor',
+        permalinkSide: 'right',
+        permalinkSymbol: '#'
       };
       const result = parse({ text });
 


### PR DESCRIPTION
Currently when a preset is set, its options can't be overridden and anchor feature cannot be used.

Updated [wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki/Advanced-Configuration#preset-options).

- BREAKING CHANGE: config syntax has been updated, old config compatibility is temporarily retained
  * Old config
  ``` yml
  markdown: 'commonmark'
  ```
  * will be automatically converted to:
  ``` yml
  markdown:
    preset: 'commonmark'
  # render, plugins & anchors options are empty
  ```
- refactor(test): set default config