### PR TITLE
feat: options to enable/disable rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ markdown:
     linkify: true
     typographer: true
     quotes: '“”‘’'
+  enable_rules:
+  disable_rules:
   plugins:
   anchors:
     level: 2

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -12,8 +12,16 @@ module.exports = function(data, options) {
     this.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
   }
 
-  const { preset, render, plugins, anchors } = markdown;
+  const { preset, render, enable_rules, disable_rules, plugins, anchors } = markdown;
   let parser = new MdIt(preset, render);
+
+  if (enable_rules) {
+    parser.enable(enable_rules);
+  }
+
+  if (disable_rules) {
+    parser.disable(disable_rules);
+  }
 
   if (plugins) {
     parser = plugins.reduce((parser, pugs) => {

--- a/test/fixtures/outputs/default-disable_rules.html
+++ b/test/fixtures/outputs/default-disable_rules.html
@@ -1,0 +1,183 @@
+<h1>h1 Heading em português</h1>
+<h2 id="h2-Heading-P">h2 Heading :P</h2>
+<h3 id="h3-Heading">h3 Heading</h3>
+<h4 id="h4-Heading">h4 Heading</h4>
+<h5 id="h5-Heading">h5 Heading</h5>
+<h6 id="h6-Heading">h6 Heading</h6>
+<h2 id="Horizontal-Rule">Horizontal Rule</h2>
+<hr>
+<h2 id="Horizontal-Rule-2">Horizontal Rule</h2>
+<hr>
+<h2 id="Horizontal-Rule-3">Horizontal Rule</h2>
+<hr>
+<h2 id="Typographic-replacements">Typographic replacements</h2>
+<p>Enable typographer option to see result.</p>
+<p>© © ® ® ™ ™ § § ±</p>
+<p>test… test… test… test?.. test!..</p>
+<p>!!! ??? ,  – —</p>
+<p>“Smartypants, double quotes” and ‘single quotes’</p>
+<h2 id="Emphasis">Emphasis</h2>
+<p><strong>This is bold text</strong></p>
+<p><strong>This is bold text</strong></p>
+<p><em>This is italic text</em></p>
+<p><em>This is italic text</em></p>
+<p><s>Strikethrough</s></p>
+<h2 id="Blockquotes">Blockquotes</h2>
+<blockquote>
+<p>Blockquotes can also be nested…</p>
+<blockquote>
+<p>…by using additional greater-than signs right next to each other…</p>
+<blockquote>
+<p>…or with spaces between arrows.</p>
+</blockquote>
+</blockquote>
+</blockquote>
+<h2 id="Lists">Lists</h2>
+<p>Unordered</p>
+<ul>
+<li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
+<li>Sub-lists are made by indenting 2 spaces:
+<ul>
+<li>Marker character change forces new list start:
+<ul>
+<li>Ac tristique libero volutpat at</li>
+</ul>
+<ul>
+<li>Facilisis in pretium nisl aliquet</li>
+</ul>
+<ul>
+<li>Nulla volutpat aliquam velit</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Very easy!</li>
+</ul>
+<p>Ordered</p>
+<ol>
+<li>Lorem ipsum dolor sit amet</li>
+<li>Consectetur adipiscing elit</li>
+<li>Integer molestie lorem at massa</li>
+</ol>
+<h2 id="Code">Code</h2>
+<p>Inline <code>code</code></p>
+<p>Indented code</p>
+<pre><code>// Some comments
+line 1 of code
+line 2 of code
+line 3 of code
+</code></pre>
+<p>Block code “fences”</p>
+<pre><code>Sample text here...
+</code></pre>
+<p>Syntax highlighting</p>
+<pre><code class="language-js">var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+</code></pre>
+<h2 id="Tables">Tables</h2>
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>data</td>
+<td>path to data files to supply the data that will be passed into templates.</td>
+</tr>
+<tr>
+<td>engine</td>
+<td>engine to be used for processing templates. Handlebars is the default.</td>
+</tr>
+<tr>
+<td>ext</td>
+<td>extension to be used for dest files.</td>
+</tr>
+</tbody>
+</table>
+<p>Right aligned columns</p>
+<table>
+<thead>
+<tr>
+<th style="text-align:right">Option</th>
+<th style="text-align:right">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:right">data</td>
+<td style="text-align:right">path to data files to supply the data that will be passed into templates.</td>
+</tr>
+<tr>
+<td style="text-align:right">engine</td>
+<td style="text-align:right">engine to be used for processing templates. Handlebars is the default.</td>
+</tr>
+<tr>
+<td style="text-align:right">ext</td>
+<td style="text-align:right">extension to be used for dest files.</td>
+</tr>
+</tbody>
+</table>
+<h2 id="Links">Links</h2>
+<p>[link text](http://dev.nodeca.com)</p>
+<p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
+<h2 id="Images">Images</h2>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion"><br>
+<img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
+<p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
+<h2 id="Plugins">Plugins</h2>
+<p>The killer feature of <code>markdown-it</code> is very effective support of<br>
+[syntax plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin).</p>
+<h3 id="Emojies-https-github-com-markdown-it-markdown-it-emoji">[Emojies](https://github.com/markdown-it/markdown-it-emoji)</h3>
+<blockquote>
+<p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>
+<p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>
+</blockquote>
+<p>see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.</p>
+<h3 id="Subscipt-https-github-com-markdown-it-markdown-it-sub-Superscirpt-https-github-com-markdown-it-markdown-it-sup">[Subscipt](https://github.com/markdown-it/markdown-it-sub) / [Superscirpt](https://github.com/markdown-it/markdown-it-sup)</h3>
+<ul>
+<li>19^th^</li>
+<li>H~2~O</li>
+</ul>
+<h3 id="ins-https-github-com-markdown-it-markdown-it-ins">[&lt;ins&gt;](https://github.com/markdown-it/markdown-it-ins)</h3>
+<p>++Inserted text++</p>
+<h3 id="mark-https-github-com-markdown-it-markdown-it-mark">[&lt;mark&gt;](https://github.com/markdown-it/markdown-it-mark)</h3>
+<p>==Marked text==</p>
+<h3 id="Footnotes-https-github-com-markdown-it-markdown-it-footnote">[Footnotes](https://github.com/markdown-it/markdown-it-footnote)</h3>
+<p>Footnote 1 link[^first].</p>
+<p>Footnote 2 link[^second].</p>
+<p>Inline footnote^[Text of inline footnote] definition.</p>
+<p>Duplicated footnote reference[^second].</p>
+<p>[^first]: Footnote <strong>can have markup</strong></p>
+<pre><code>and multiple paragraphs.
+</code></pre>
+<p>[^second]: Footnote text.</p>
+<h3 id="Definition-lists-https-github-com-markdown-it-markdown-it-deflist">[Definition lists](https://github.com/markdown-it/markdown-it-deflist)</h3>
+<p>Term 1</p>
+<p>:   Definition 1<br>
+with lazy continuation.</p>
+<p>Term 2 with <em>inline markup</em></p>
+<p>:   Definition 2</p>
+<pre><code>    { some code, part of Definition 2 }
+
+Third paragraph of definition 2.
+</code></pre>
+<p><em>Compact style:</em></p>
+<p>Term 1<br>
+~ Definition 1</p>
+<p>Term 2<br>
+~ Definition 2a<br>
+~ Definition 2b</p>
+<h3 id="Abbreviations-https-github-com-markdown-it-markdown-it-abbr">[Abbreviations](https://github.com/markdown-it/markdown-it-abbr)</h3>
+<p>This is HTML abbreviation example.</p>
+<p>It converts “HTML”, but keep intact partial entries like “xxxHTMLyyy” and so on.</p>
+<p>*[HTML]: Hyper Text Markup Language</p>
+<h3 id="Custom-containers-https-github-com-markdown-it-markdown-it-container">[Custom containers](https://github.com/markdown-it/markdown-it-container)</h3>
+<p>::: warning<br>
+<em>here be dragons</em><br>
+:::</p>

--- a/test/fixtures/outputs/zero-enable_rules.html
+++ b/test/fixtures/outputs/zero-enable_rules.html
@@ -1,0 +1,124 @@
+<p># h1 Heading em português
+## h2 Heading :P
+### h3 Heading
+#### h4 Heading
+##### h5 Heading
+###### h6 Heading</p>
+<p>## Horizontal Rule</p>
+<p>___</p>
+<p>## Horizontal Rule</p>
+<p>---</p>
+<p>## Horizontal Rule</p>
+<p>***</p>
+<p>## Typographic replacements</p>
+<p>Enable typographer option to see result.</p>
+<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>
+<p>test.. test... test..... test?..... test!....</p>
+<p>!!!!!! ???? ,,  -- ---</p>
+<p>&quot;Smartypants, double quotes&quot; and 'single quotes'</p>
+<p>## Emphasis</p>
+<p>**This is bold text**</p>
+<p>__This is bold text__</p>
+<p>*This is italic text*</p>
+<p>_This is italic text_</p>
+<p>~~Strikethrough~~</p>
+<p>## Blockquotes</p>
+<p>&gt; Blockquotes can also be nested...
+&gt;&gt; ...by using additional greater-than signs right next to each other...
+&gt; &gt; &gt; ...or with spaces between arrows.</p>
+<p>## Lists</p>
+<p>Unordered</p>
+<p>+ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ Very easy!</p>
+<p>Ordered</p>
+<p>1. Lorem ipsum dolor sit amet
+2. Consectetur adipiscing elit
+3. Integer molestie lorem at massa</p>
+<p>## Code</p>
+<p>Inline `code`</p>
+<p>Indented code</p>
+<p>// Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code</p>
+<p>Block code &quot;fences&quot;</p>
+<p>```
+Sample text here...
+```</p>
+<p>Syntax highlighting</p>
+<p>``` js
+var foo = function (bar) {
+  return bar++;
+};</p>
+<p>console.log(foo(5));
+```</p>
+<p>## Tables</p>
+<p>| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |</p>
+<p>Right aligned columns</p>
+<p>| Option | Description |
+| ------:| -----------:|
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |</p>
+<p>## Links</p>
+<p><a href="http://dev.nodeca.com">link text</a></p>
+<p>Autoconverted link https://github.com/nodeca/pica (enable linkify to see)</p>
+<p>## Images</p>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
+<img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
+<p>![Alt text][id]</p>
+<p>[id]: https://octodex.github.com/images/dojocat.jpg  &quot;The Dojocat&quot;</p>
+<p>## Plugins</p>
+<p>The killer feature of `markdown-it` is very effective support of
+<a href="https://www.npmjs.org/browse/keyword/markdown-it-plugin">syntax plugins</a>.</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-emoji">Emojies</a></p>
+<p>&gt; Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:
+&gt;
+&gt; Shortcuts (emoticons): :-) :-( 8-) ;)</p>
+<p>see <a href="https://github.com/markdown-it/markdown-it-emoji#change-output">how to change output</a> with twemoji.</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-sub">Subscipt</a> / <a href="https://github.com/markdown-it/markdown-it-sup">Superscirpt</a></p>
+<p>- 19^th^
+- H~2~O</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-ins">\&lt;ins&gt;</a></p>
+<p>++Inserted text++</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-mark">\&lt;mark&gt;</a></p>
+<p>==Marked text==</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-footnote">Footnotes</a></p>
+<p>Footnote 1 link[^first].</p>
+<p>Footnote 2 link[^second].</p>
+<p>Inline footnote^[Text of inline footnote] definition.</p>
+<p>Duplicated footnote reference[^second].</p>
+<p>[^first]: Footnote **can have markup**</p>
+<p>and multiple paragraphs.</p>
+<p>[^second]: Footnote text.</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-deflist">Definition lists</a></p>
+<p>Term 1</p>
+<p>:   Definition 1
+with lazy continuation.</p>
+<p>Term 2 with *inline markup*</p>
+<p>:   Definition 2</p>
+<p>{ some code, part of Definition 2 }</p>
+<p>Third paragraph of definition 2.</p>
+<p>_Compact style:_</p>
+<p>Term 1
+  ~ Definition 1</p>
+<p>Term 2
+  ~ Definition 2a
+  ~ Definition 2b</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-abbr">Abbreviations</a></p>
+<p>This is HTML abbreviation example.</p>
+<p>It converts &quot;HTML&quot;, but keep intact partial entries like &quot;xxxHTMLyyy&quot; and so on.</p>
+<p>*[HTML]: Hyper Text Markup Language</p>
+<p>### <a href="https://github.com/markdown-it/markdown-it-container">Custom containers</a></p>
+<p>::: warning
+*here be dragons*
+:::</p>

--- a/test/index.js
+++ b/test/index.js
@@ -161,6 +161,29 @@ describe('Hexo Renderer Markdown-it', () => {
     result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
   });
 
+  it('enable_rules', () => {
+    hexo.config.markdown.preset = 'zero';
+    hexo.config.markdown.enable_rules = ['link', 'image'];
+
+    const parsed_zero = fs.readFileSync('./test/fixtures/outputs/zero-enable_rules.html', 'utf8');
+    const result = parse({
+      text: source
+    });
+    result.should.equal(parsed_zero);
+  });
+
+  it('disable_rules', () => {
+    hexo.config.markdown.preset = 'default';
+    hexo.config.markdown.render.linkify = false;
+    hexo.config.markdown.disable_rules = 'link';
+
+    const parsed = fs.readFileSync('./test/fixtures/outputs/default-disable_rules.html', 'utf8');
+    const result = parse({
+      text: source
+    });
+    result.should.equal(parsed);
+  });
+
   describe('execFilter', () => {
     it('default', () => {
       const result = parse({
@@ -181,7 +204,6 @@ describe('Hexo Renderer Markdown-it', () => {
 
     });
   });
-
 
   describe('anchors - permalinkSide', () => {
     const text = '## foo';


### PR DESCRIPTION
Based on #38 credit @jGleitz 

Some [rules](https://github.com/markdown-it/markdown-it#manage-rules) are enabled or disabled depending on the preset. For example, `zero` preset disable all rules, `enable_rules` allows enabling specific rules; `default` preset enables all rules, `disable_rules` is vice-versa.

Updated [wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki/Advanced-Configuration#manage-rules).