### PR TITLE
test: 'langPrefix' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ markdown:
   render:
     html: true
     xhtmlOut: false
+    langPrefix: 'language-'
     breaks: true
     linkify: true
     typographer: true

--- a/test/index.js
+++ b/test/index.js
@@ -78,23 +78,35 @@ describe('Hexo Renderer Markdown-it', () => {
     result.should.equal(parsed_gfm);
   });
 
-  it('should handle a custom configuration', () => {
-    hexo.config.markdown.render = {
-      html: false,
-      xhtmlOut: true,
-      breaks: true,
-      langPrefix: '',
-      linkify: true,
-      typographer: true,
-      quotes: '«»“”'
-    };
+  describe('render options', () => {
+    it('custom options', () => {
+      hexo.config.markdown.render = {
+        html: false,
+        xhtmlOut: true,
+        breaks: true,
+        langPrefix: '',
+        linkify: true,
+        typographer: true,
+        quotes: '«»“”'
+      };
 
-    const parsed_custom = fs.readFileSync('./test/fixtures/outputs/custom.html', 'utf8');
-    const source = fs.readFileSync('./test/fixtures/markdownit.md', 'utf8');
-    const result = parse({
-      text: source
+      const parsed_custom = fs.readFileSync('./test/fixtures/outputs/custom.html', 'utf8');
+      const source = fs.readFileSync('./test/fixtures/markdownit.md', 'utf8');
+      const result = parse({
+        text: source
+      });
+      result.should.equal(parsed_custom);
     });
-    result.should.equal(parsed_custom);
+
+    it('langPrefix', () => {
+      hexo.config.markdown.render = {
+        langPrefix: 'lang-'
+      };
+
+      const text = '```js\nexample\n```';
+      const result = parse({ text });
+      result.should.eql('<pre><code class="lang-js">example\n</code></pre>\n');
+    });
   });
 
   it('should render plugins if they are defined', () => {


### PR DESCRIPTION
The option is already supported (it's parsed to markdown-it by default).
Closes https://github.com/hexojs/hexo-renderer-markdown-it/issues/97
Added to [guide](https://github.com/hexojs/hexo-renderer-markdown-it/wiki/Advanced-Configuration#langprefix).