### PR TITLE
docs(slugize): default separator is a dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ markdown:
     permalinkSide: 'left'
     permalinkSymbol: '¶'
     case: 0
-    separator: ''
+    separator: '-'
 ```
 
 Refer to [the wiki](https://github.com/hexojs/hexo-renderer-markdown-it/wiki) for more details.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ hexo.config.markdown.anchors = Object.assign({
   permalinkSide: 'left',
   permalinkSymbol: '¶',
   case: 0,
-  separator: ''
+  separator: '-'
 }, hexo.config.markdown.anchors);
 
 const renderer = require('./lib/renderer');


### PR DESCRIPTION
- https://github.com/hexojs/hexo-util#slugizestr-options