### PR TITLE
perf(#57): avoid creating instance each time when render each file

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,14 +28,19 @@ hexo.config.markdown.anchors = Object.assign({
   separator: '-'
 }, hexo.config.markdown.anchors);
 
-const renderer = require('./lib/renderer');
+const Renderer = require('./lib/renderer');
+const renderer = new Renderer(hexo);
 
 renderer.disableNunjucks = Boolean(hexo.config.markdown.disableNunjucks);
 
-hexo.extend.renderer.register('md', 'html', renderer, true);
-hexo.extend.renderer.register('markdown', 'html', renderer, true);
-hexo.extend.renderer.register('mkd', 'html', renderer, true);
-hexo.extend.renderer.register('mkdn', 'html', renderer, true);
-hexo.extend.renderer.register('mdwn', 'html', renderer, true);
-hexo.extend.renderer.register('mdtxt', 'html', renderer, true);
-hexo.extend.renderer.register('mdtext', 'html', renderer, true);
+function render(data, options) {
+  return renderer.parser.render(data.text);
+}
+
+hexo.extend.renderer.register('md', 'html', render, true);
+hexo.extend.renderer.register('markdown', 'html', render, true);
+hexo.extend.renderer.register('mkd', 'html', render, true);
+hexo.extend.renderer.register('mkdn', 'html', render, true);
+hexo.extend.renderer.register('mdwn', 'html', render, true);
+hexo.extend.renderer.register('mdtxt', 'html', render, true);
+hexo.extend.renderer.register('mdtext', 'html', render, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -6,7 +6,7 @@ class Renderer {
 
   /**
    * constructor
-   * 
+   *
    * @param {*} hexo context of hexo
    */
   constructor(hexo) {
@@ -48,4 +48,4 @@ class Renderer {
   }
 }
 
-module.exports = Renderer
+module.exports = Renderer;

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,43 +1,51 @@
 'use strict';
 
-module.exports = function(data, options) {
-  const MdIt = require('markdown-it');
-  let { markdown } = this.config;
+const MarkdownIt = require('markdown-it');
 
-  // Temporary backward compatibility
-  if (typeof markdown === 'string') {
-    markdown = {
-      preset: markdown
-    };
-    this.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
+class Renderer {
+
+  /**
+   * constructor
+   * 
+   * @param {*} hexo context of hexo
+   */
+  constructor(hexo) {
+
+    let { markdown } = hexo.config;
+
+    // Temporary backward compatibility
+    if (typeof markdown === 'string') {
+      markdown = {
+        preset: markdown
+      };
+      hexo.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
+    }
+
+    const { preset, render, enable_rules, disable_rules, plugins, anchors } = markdown;
+    this.parser = new MarkdownIt(preset, render);
+
+    if (enable_rules) {
+      this.parser.enable(enable_rules);
+    }
+
+    if (disable_rules) {
+      this.parser.disable(disable_rules);
+    }
+
+    if (plugins) {
+      this.parser = plugins.reduce((parser, pugs) => {
+        if (pugs instanceof Object && pugs.name) {
+          return parser.use(require(pugs.name), pugs.options);
+        }
+        return parser.use(require(pugs));
+      }, this.parser);
+    }
+
+    if (anchors) {
+      this.parser.use(require('./anchors'), anchors);
+    }
+    hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
   }
+}
 
-  const { preset, render, enable_rules, disable_rules, plugins, anchors } = markdown;
-  let parser = new MdIt(preset, render);
-
-  if (enable_rules) {
-    parser.enable(enable_rules);
-  }
-
-  if (disable_rules) {
-    parser.disable(disable_rules);
-  }
-
-  if (plugins) {
-    parser = plugins.reduce((parser, pugs) => {
-      if (pugs instanceof Object && pugs.name) {
-        return parser.use(require(pugs.name), pugs.options);
-      }
-      return parser.use(require(pugs));
-
-    }, parser);
-  }
-
-  if (anchors) {
-    parser = parser.use(require('./anchors'), anchors);
-  }
-
-  this.execFilterSync('markdown-it:renderer', parser, { context: this });
-
-  return parser.render(data.text);
-};
+module.exports = Renderer

--- a/test/index.js
+++ b/test/index.js
@@ -41,8 +41,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'default';
 
       const parsed_gfm = readFileSync('./test/fixtures/outputs/default.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
 
       result.should.equal(parsed_gfm);
     });
@@ -51,7 +51,7 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'commonmark';
 
       const parsed_commonmark = readFileSync('./test/fixtures/outputs/commonmark.html', 'utf8');
-      const renderer = new Renderer(hexo)
+      const renderer = new Renderer(hexo);
       const result = renderer.parser.render(source);
 
       result.should.equal(parsed_commonmark);
@@ -62,8 +62,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown = 'commonmark';
 
       const parsed_commonmark = readFileSync('./test/fixtures/outputs/commonmark-deprecated.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
 
       result.should.equal(parsed_commonmark);
     });
@@ -72,8 +72,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'zero';
 
       const parsed_zero = readFileSync('./test/fixtures/outputs/zero.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
       result.should.equal(parsed_zero);
     });
   });
@@ -92,8 +92,8 @@ describe('Hexo Renderer Markdown-it', () => {
 
       const parsed_custom = readFileSync('./test/fixtures/outputs/custom.html', 'utf8');
       const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
       result.should.equal(parsed_custom);
     });
 
@@ -103,8 +103,8 @@ describe('Hexo Renderer Markdown-it', () => {
       };
 
       const text = '```js\nexample\n```';
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(text)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(text);
       result.should.eql('<pre><code class="lang-js">example\n</code></pre>\n');
     });
   });
@@ -125,8 +125,8 @@ describe('Hexo Renderer Markdown-it', () => {
 
       const parsed_plugins = readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
       const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
       result.should.equal(parsed_plugins);
     });
 
@@ -143,8 +143,8 @@ describe('Hexo Renderer Markdown-it', () => {
       ];
 
       const text = ':smile:';
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(text)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(text);
       result.should.equal('<p>:lorem:</p>\n');
     });
   });
@@ -159,8 +159,8 @@ describe('Hexo Renderer Markdown-it', () => {
         permalinkSymbol: '¶'
       };
       const expected = readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
 
       result.should.eql(expected);
     });
@@ -174,8 +174,8 @@ describe('Hexo Renderer Markdown-it', () => {
         permalinkSymbol: '¶'
       };
 
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render('# This is an H1 title\n# This is an H1 title')
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render('# This is an H1 title\n# This is an H1 title');
       const expected = '<h1 id="This-is-an-H1-title">This is an H1 title</h1>\n<h1 id="This-is-an-H1-title-2">This is an H1 title</h1>\n';
 
       result.should.eql(expected);
@@ -188,8 +188,8 @@ describe('Hexo Renderer Markdown-it', () => {
         separator: '_'
       };
 
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render('## foo BAR')
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render('## foo BAR');
 
       result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
     });
@@ -205,8 +205,8 @@ describe('Hexo Renderer Markdown-it', () => {
           permalinkSide: 'left',
           permalinkSymbol: '#'
         };
-        const renderer = new Renderer(hexo)
-        const result = renderer.parser.render(text)
+        const renderer = new Renderer(hexo);
+        const result = renderer.parser.render(text);
 
         result.should.equal('<h2 id="foo"><a class="anchor" href="#foo">#</a>foo</h2>\n');
       });
@@ -219,8 +219,8 @@ describe('Hexo Renderer Markdown-it', () => {
           permalinkSide: 'right',
           permalinkSymbol: '#'
         };
-        const renderer = new Renderer(hexo)
-        const result = renderer.parser.render(text)
+        const renderer = new Renderer(hexo);
+        const result = renderer.parser.render(text);
 
         result.should.equal('<h2 id="foo">foo<a class="anchor" href="#foo">#</a></h2>\n');
       });
@@ -233,8 +233,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.enable_rules = ['link', 'image'];
 
       const parsed_zero = readFileSync('./test/fixtures/outputs/zero-enable_rules.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
 
       result.should.equal(parsed_zero);
     });
@@ -245,8 +245,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.disable_rules = 'link';
 
       const parsed = readFileSync('./test/fixtures/outputs/default-disable_rules.html', 'utf8');
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render(source)
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
 
       result.should.equal(parsed);
     });
@@ -255,8 +255,8 @@ describe('Hexo Renderer Markdown-it', () => {
   describe('execFilter', () => {
     it('default', () => {
 
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render('[foo](javascript:bar)')
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render('[foo](javascript:bar)');
 
       result.should.equal('<p>[foo](javascript:bar)</p>\n');
     });
@@ -266,8 +266,8 @@ describe('Hexo Renderer Markdown-it', () => {
         md.validateLink = function() { return true; };
       });
 
-      const renderer = new Renderer(hexo)
-      const result = renderer.parser.render('[foo](javascript:bar)')
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render('[foo](javascript:bar)');
 
       result.should.equal('<p><a href="javascript:bar">foo</a></p>\n');
     });
@@ -280,9 +280,9 @@ describe('Hexo Renderer Markdown-it', () => {
 
     before(async () => {
       await hexo.init();
-      hexo.config.markdown = {}
+      hexo.config.markdown = {};
 
-      const renderer = new Renderer(hexo)
+      const renderer = new Renderer(hexo);
       function render(data, options) {
         return renderer.parser.render(data.text);
       }

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,12 @@
 
 require('chai').should();
 const { readFileSync } = require('fs');
-const render = require('../lib/renderer');
+const Renderer = require('../lib/renderer');
 const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
 const Hexo = require('hexo');
 
 describe('Hexo Renderer Markdown-it', () => {
   const hexo = new Hexo(__dirname, { silent: true });
-  const parse = render.bind(hexo);
   const defaultCfg = JSON.parse(JSON.stringify(Object.assign(hexo.config, {
     markdown: {
       preset: 'default',
@@ -42,9 +41,9 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'default';
 
       const parsed_gfm = readFileSync('./test/fixtures/outputs/default.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
+
       result.should.equal(parsed_gfm);
     });
 
@@ -52,9 +51,9 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'commonmark';
 
       const parsed_commonmark = readFileSync('./test/fixtures/outputs/commonmark.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source);
+
       result.should.equal(parsed_commonmark);
     });
 
@@ -63,9 +62,9 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown = 'commonmark';
 
       const parsed_commonmark = readFileSync('./test/fixtures/outputs/commonmark-deprecated.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
+
       result.should.equal(parsed_commonmark);
     });
 
@@ -73,9 +72,8 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.preset = 'zero';
 
       const parsed_zero = readFileSync('./test/fixtures/outputs/zero.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
       result.should.equal(parsed_zero);
     });
   });
@@ -94,9 +92,8 @@ describe('Hexo Renderer Markdown-it', () => {
 
       const parsed_custom = readFileSync('./test/fixtures/outputs/custom.html', 'utf8');
       const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
       result.should.equal(parsed_custom);
     });
 
@@ -106,7 +103,8 @@ describe('Hexo Renderer Markdown-it', () => {
       };
 
       const text = '```js\nexample\n```';
-      const result = parse({ text });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(text)
       result.should.eql('<pre><code class="lang-js">example\n</code></pre>\n');
     });
   });
@@ -127,9 +125,8 @@ describe('Hexo Renderer Markdown-it', () => {
 
       const parsed_plugins = readFileSync('./test/fixtures/outputs/plugins.html', 'utf8');
       const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
       result.should.equal(parsed_plugins);
     });
 
@@ -146,7 +143,8 @@ describe('Hexo Renderer Markdown-it', () => {
       ];
 
       const text = ':smile:';
-      const result = parse({ text });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(text)
       result.should.equal('<p>:lorem:</p>\n');
     });
   });
@@ -161,9 +159,8 @@ describe('Hexo Renderer Markdown-it', () => {
         permalinkSymbol: '¶'
       };
       const expected = readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
 
       result.should.eql(expected);
     });
@@ -176,9 +173,9 @@ describe('Hexo Renderer Markdown-it', () => {
         permalinkClass: 'header-anchor',
         permalinkSymbol: '¶'
       };
-      const result = parse({
-        text: '# This is an H1 title\n# This is an H1 title'
-      });
+
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render('# This is an H1 title\n# This is an H1 title')
       const expected = '<h1 id="This-is-an-H1-title">This is an H1 title</h1>\n<h1 id="This-is-an-H1-title-2">This is an H1 title</h1>\n';
 
       result.should.eql(expected);
@@ -191,9 +188,8 @@ describe('Hexo Renderer Markdown-it', () => {
         separator: '_'
       };
 
-      const result = parse({
-        text: '## foo BAR'
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render('## foo BAR')
 
       result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
     });
@@ -209,7 +205,8 @@ describe('Hexo Renderer Markdown-it', () => {
           permalinkSide: 'left',
           permalinkSymbol: '#'
         };
-        const result = parse({ text });
+        const renderer = new Renderer(hexo)
+        const result = renderer.parser.render(text)
 
         result.should.equal('<h2 id="foo"><a class="anchor" href="#foo">#</a>foo</h2>\n');
       });
@@ -222,7 +219,8 @@ describe('Hexo Renderer Markdown-it', () => {
           permalinkSide: 'right',
           permalinkSymbol: '#'
         };
-        const result = parse({ text });
+        const renderer = new Renderer(hexo)
+        const result = renderer.parser.render(text)
 
         result.should.equal('<h2 id="foo">foo<a class="anchor" href="#foo">#</a></h2>\n');
       });
@@ -235,9 +233,9 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.enable_rules = ['link', 'image'];
 
       const parsed_zero = readFileSync('./test/fixtures/outputs/zero-enable_rules.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
+
       result.should.equal(parsed_zero);
     });
 
@@ -247,18 +245,19 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.config.markdown.disable_rules = 'link';
 
       const parsed = readFileSync('./test/fixtures/outputs/default-disable_rules.html', 'utf8');
-      const result = parse({
-        text: source
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render(source)
+
       result.should.equal(parsed);
     });
   });
 
   describe('execFilter', () => {
     it('default', () => {
-      const result = parse({
-        text: '[foo](javascript:bar)'
-      });
+
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render('[foo](javascript:bar)')
+
       result.should.equal('<p>[foo](javascript:bar)</p>\n');
     });
 
@@ -267,9 +266,9 @@ describe('Hexo Renderer Markdown-it', () => {
         md.validateLink = function() { return true; };
       });
 
-      const result = parse({
-        text: '[foo](javascript:bar)'
-      });
+      const renderer = new Renderer(hexo)
+      const result = renderer.parser.render('[foo](javascript:bar)')
+
       result.should.equal('<p><a href="javascript:bar">foo</a></p>\n');
     });
   });
@@ -281,11 +280,16 @@ describe('Hexo Renderer Markdown-it', () => {
 
     before(async () => {
       await hexo.init();
-      hexo.extend.tag.register('lorem', loremFn);
-      hexo.extend.renderer.register('md', 'html', require('../lib/renderer'), true);
-    });
+      hexo.config.markdown = {}
 
-    beforeEach(() => { hexo.config.markdown = {}; });
+      const renderer = new Renderer(hexo)
+      function render(data, options) {
+        return renderer.parser.render(data.text);
+      }
+
+      hexo.extend.tag.register('lorem', loremFn);
+      hexo.extend.renderer.register('md', 'html', render, true);
+    });
 
     it('default', async () => {
       const result = await hexo.post.render(null, { content: '**foo** {% lorem %}', engine });


### PR DESCRIPTION
Fix: #57 

It is mentioned in #57 no need to create a new markdonw-it instance for each file.