### PR TITLE
fix(#135): filter was executed before it was loaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const renderer = new Renderer(hexo);
 renderer.disableNunjucks = Boolean(hexo.config.markdown.disableNunjucks);
 
 function render(data, options) {
-  return renderer.parser.render(data.text);
+  return renderer.render(data, options);
 }
 
 hexo.extend.renderer.register('md', 'html', render, true);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -10,6 +10,7 @@ class Renderer {
    * @param {*} hexo context of hexo
    */
   constructor(hexo) {
+    this.hexo = hexo;
 
     let { markdown } = hexo.config;
 
@@ -44,7 +45,11 @@ class Renderer {
     if (anchors) {
       this.parser.use(require('./anchors'), anchors);
     }
-    hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
+  }
+
+  render(data, options) {
+    this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
+    return this.parser.render(data.text);
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -262,17 +262,32 @@ describe('Hexo Renderer Markdown-it', () => {
     });
 
     it('enable unsafe link', () => {
-      hexo.extend.filter.register('markdown-it:renderer', md => {
+      const filter = md => {
         md.validateLink = function() { return true; };
-      });
+      };
+      hexo.extend.filter.register('markdown-it:renderer', filter);
 
       const renderer = new Renderer(hexo);
+      const result = renderer.render({ text: '[foo](javascript:bar)' });
+
+      hexo.extend.filter.unregister('markdown-it:renderer', filter);
+
+      result.should.equal('<p><a href="javascript:bar">foo</a></p>\n');
+    });
+
+    it('should execute loaded scripts', async () => {
+      const renderer = new Renderer(hexo);
+
+      hexo.env.init = true;
+      await hexo.init();
+
       const result = renderer.render({ text: '[foo](javascript:bar)' });
 
       result.should.equal('<p><a href="javascript:bar">foo</a></p>\n');
     });
 
     it('should be called in render', () => {
+      const iterates = 3;
       const spy = {
         called: 0,
         call() {
@@ -280,16 +295,17 @@ describe('Hexo Renderer Markdown-it', () => {
         }
       };
 
-      hexo.extend.filter.register('markdown-it:renderer', md => {
-        spy.call(md);
-      });
+      const filter = md => spy.call(md);
+      hexo.extend.filter.register('markdown-it:renderer', filter);
 
       const renderer = new Renderer(hexo);
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < iterates; i++) {
         renderer.render({ text: '' });
       }
 
-      spy.called.should.equal(3);
+      hexo.extend.filter.unregister('markdown-it:renderer', filter);
+
+      spy.called.should.equal(iterates);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -256,7 +256,7 @@ describe('Hexo Renderer Markdown-it', () => {
     it('default', () => {
 
       const renderer = new Renderer(hexo);
-      const result = renderer.parser.render('[foo](javascript:bar)');
+      const result = renderer.render({ text: '[foo](javascript:bar)' });
 
       result.should.equal('<p>[foo](javascript:bar)</p>\n');
     });
@@ -267,9 +267,29 @@ describe('Hexo Renderer Markdown-it', () => {
       });
 
       const renderer = new Renderer(hexo);
-      const result = renderer.parser.render('[foo](javascript:bar)');
+      const result = renderer.render({ text: '[foo](javascript:bar)' });
 
       result.should.equal('<p><a href="javascript:bar">foo</a></p>\n');
+    });
+
+    it('should be called in render', () => {
+      const spy = {
+        called: 0,
+        call() {
+          this.called++;
+        }
+      };
+
+      hexo.extend.filter.register('markdown-it:renderer', md => {
+        spy.call(md);
+      });
+
+      const renderer = new Renderer(hexo);
+      for (let i = 0; i < 3; i++) {
+        renderer.render({ text: '' });
+      }
+
+      spy.called.should.equal(3);
     });
   });
 

--- a/test/scripts/enable_unsafe_link.js
+++ b/test/scripts/enable_unsafe_link.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// eslint-disable-next-line no-undef
+hexo.extend.filter.register('markdown-it:renderer', md => {
+  md.validateLink = function() { return true; };
+});


### PR DESCRIPTION
The [filter](https://github.com/hexojs/hexo-renderer-markdown-it#extensibility) won't be work after upgrade to [v6.0.0](https://github.com/hexojs/hexo-renderer-markdown-it/releases/tag/6.0.0)

The hexo [loadScripts after loadModules](https://github.com/hexojs/hexo/blob/f12a8db03b392bb5c32c0649302a3d0cc8768832/lib/hexo/load_plugins.js#L11)
<img width="472" alt="image" src="https://user-images.githubusercontent.com/12423122/152194184-ffa8e946-e897-4cc8-b62f-bd6c75bac79e.png">


When this plugin being required and loaded by [loadModules](https://github.com/hexojs/hexo/blob/f12a8db03b392bb5c32c0649302a3d0cc8768832/lib/hexo/load_plugins.js#L47), the `Renderer` constructed and the filter `markdown-it:renderer` was executed at this time.
https://github.com/hexojs/hexo-renderer-markdown-it/blob/4d4d4bdf74acfc8b11ac5021e5e2026ac2e62989/lib/renderer.js#L47

But the script that contains implementation of filter was loaded by  [loadScripts](https://github.com/hexojs/hexo/blob/f12a8db03b392bb5c32c0649302a3d0cc8768832/lib/hexo/load_plugins.js#L62). So that, the filter has no chance to run.

I had checked how this mechanisms be implemented in another similar plugin [hexo-renderer-marked](https://github.com/hexojs/hexo-renderer-marked). and the code in [v5.0.0](https://github.com/hexojs/hexo-renderer-markdown-it/releases/tag/5.0.0)

I found that the filter should be executed when each render processed.


BTW: The [hexo-renderer-marked](https://github.com/hexojs/hexo-renderer-marked) [execFilter](https://github.com/hexojs/hexo-renderer-marked/blob/43046017d358e9a141d338d18638b0690281f2c4/lib/renderer.js#L211) in [render](https://github.com/hexojs/hexo-renderer-marked/blob/43046017d358e9a141d338d18638b0690281f2c4/index.js#L33) process.


BTW2: Another way to fix this issue:
Wrap the execFilter with [before_post_render](https://hexo.io/api/filter.html#before-post-render)
```js
hexo.extend.filter.register('before_post_render', () => {
    hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
});
```