### PR TITLE
fix: clear title cache after rendering of a post

### DIFF
--- a/lib/anchors.js
+++ b/lib/anchors.js
@@ -22,7 +22,7 @@ const renderPermalink = function(slug, opts, tokens, idx) {
 const anchor = function(md, opts) {
   Object.assign(opts, { renderPermalink });
 
-  const titleStore = {};
+  let titleStore = {};
   const originalHeadingOpen = md.renderer.rules.heading_open;
   const slugOpts = { transform: opts.case, ...opts };
 
@@ -58,6 +58,10 @@ const anchor = function(md, opts) {
       ? originalHeadingOpen.apply(this, args)
       : self.renderToken.apply(self, args);
   };
+
+  md.core.ruler.push('clear_anchor_title_store', () => {
+    titleStore = {};
+  });
 };
 
 module.exports = anchor;

--- a/test/index.js
+++ b/test/index.js
@@ -194,6 +194,23 @@ describe('Hexo Renderer Markdown-it', () => {
       result.should.equal('<h2 id="foo_bar">foo BAR</h2>\n');
     });
 
+    it('multiple posts anchor id', () => {
+      hexo.config.markdown.anchors = {
+        level: 2,
+        collisionSuffix: 'ver',
+        permalink: true,
+        permalinkClass: 'header-anchor',
+        permalinkSymbol: '¶'
+      };
+      const expected = readFileSync('./test/fixtures/outputs/anchors.html', 'utf8');
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(source);
+      const result2 = renderer.parser.render(source);
+
+      result.should.eql(expected);
+      result2.should.eql(expected);
+    });
+
     describe('permalinkSide', () => {
       const text = '## foo';
 


### PR DESCRIPTION
## Problem

After #135, using the same heading in different posts caused the rendered posts' anchor id to be add unnecessarily suffixes.

## Reproduction

**_posts/post-1.md**

```markdown
---
title: Post 1
---

## Development

## Production
```

will be rendered to:

```html
<h2 id="Development">Development</h2>
<h2 id="Production">Production</h2>
```

---

**_posts/post-2.md**

```markdown
---
title: Post 2
---

## Development

## Production
```

will be rendered to:

```html
<h2 id="Development-2">Development</h2>
<h2 id="Production-2">Production</h2>
```

actually the result should as same as **_posts/post-1.md**.
