### PR TITLE
feat: add image options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ markdown:
     permalinkSymbol: '¶'
     case: 0
     separator: '-'
+  images:
+    lazyload: false
+    prepend_root: false
+    post_asset: false
 ```
 
 See below for more details.

--- a/lib/images.js
+++ b/lib/images.js
@@ -1,12 +1,13 @@
 'use strict';
 
-const { join, relative, basename, extname, dirname } = require('path').posix;
+const { join, relative: relativePosix } = require('path').posix;
+const { relative, basename, extname, dirname, isAbsolute } = require('path');
 const { url_for } = require('hexo-util');
 
 function images(md, opts) {
   const { hexo, images } = opts;
   const { lazyload, prepend_root: prependRoot, post_asset: postAsset } = images;
-  const { relative_link, model, source_dir } = hexo;
+  const { relative_link, model, base_dir, source_dir } = hexo;
 
   md.renderer.rules.image = function(tokens, idx, options, env, self) {
     const token = tokens[idx];
@@ -25,7 +26,10 @@ function images(md, opts) {
     if (!/^(#|\/\/|http(s)?:)/.test(src) && !relative_link) {
       if (!(src.startsWith('/') || src.startsWith('\\')) && postAsset) {
         const PostAsset = model.call(hexo, 'PostAsset');
-        const assetDirBasePath = join(basename(source_dir), dirname(relative(source_dir, postPath)), basename(postPath, extname(postPath)));
+        let assetDirBasePath = join(basename(source_dir), dirname(relativePosix(source_dir, postPath)), basename(postPath, extname(postPath)));
+        if (isAbsolute(assetDirBasePath)) assetDirBasePath = relative(base_dir, assetDirBasePath);
+        assetDirBasePath = assetDirBasePath.replace(/\\/g, '/');
+
         const asset = [
           join(assetDirBasePath, src),
           join(assetDirBasePath, src.replace(new RegExp('^' + basename(postPath, extname(postPath)) + '/'), ''))

--- a/lib/images.js
+++ b/lib/images.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { join, relative, basename, extname, dirname } = require('path/posix');
+const { url_for } = require('hexo-util');
+
+function images(md, opts) {
+  const { hexo, images } = opts;
+  const { lazyload, prepend_root: prependRoot, post_asset: postAsset } = images;
+  const { relative_link, model, source_dir } = hexo;
+
+  md.renderer.rules.image = function(tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    const { postPath } = env;
+
+    if (lazyload) {
+      token.attrSet('loading', 'lazy');
+    }
+
+    if (!prependRoot && !postAsset) {
+      return self.renderToken(tokens, idx, options);
+    }
+
+    const srcIdx = token.attrs.findIndex(attr => attr[0] === 'src');
+    let src = token.attrs[srcIdx][1];
+    if (!/^(#|\/\/|http(s)?:)/.test(src) && !relative_link) {
+      if (!(src.startsWith('/') || src.startsWith('\\')) && postAsset) {
+        const PostAsset = model.call(hexo, 'PostAsset');
+        const assetDirBasePath = join(basename(source_dir), dirname(relative(source_dir, postPath)), basename(postPath, extname(postPath)));
+        const asset = [
+          join(assetDirBasePath, src),
+          join(assetDirBasePath, src.replace(new RegExp('^' + basename(postPath, extname(postPath)) + '/'), ''))
+        ]
+          .map(id => PostAsset.findById(id))
+          .filter(Boolean);
+
+        if (asset.length) {
+          src = asset[0].path.replace(/\\/g, '/');
+        }
+      }
+
+      token.attrSet('src', url_for.call(hexo, src));
+    }
+
+    return self.renderToken(tokens, idx, options);
+  };
+}
+
+module.exports = images;

--- a/lib/images.js
+++ b/lib/images.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { join, relative, basename, extname, dirname } = require('path/posix');
+const { join, relative, basename, extname, dirname } = require('path').posix;
 const { url_for } = require('hexo-util');
 
 function images(md, opts) {

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -22,7 +22,7 @@ class Renderer {
       hexo.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
     }
 
-    const { preset, render, enable_rules, disable_rules, plugins, anchors } = markdown;
+    const { preset, render, enable_rules, disable_rules, plugins, anchors, images } = markdown;
     this.parser = new MarkdownIt(preset, render);
 
     if (enable_rules) {
@@ -45,11 +45,20 @@ class Renderer {
     if (anchors) {
       this.parser.use(require('./anchors'), anchors);
     }
+
+    if (images) {
+      this.parser.use(require('./images'), {
+        images,
+        hexo: this.hexo
+      });
+    }
   }
 
   render(data, options) {
     this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
-    return this.parser.render(data.text);
+    return this.parser.render(data.text, {
+      postPath: data.path
+    });
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@
 
 require('chai').should();
 const { readFileSync } = require('fs');
-const { join } = require('path/posix');
+const { join } = require('path').posix;
 const { sep } = require('path');
 const Renderer = require('../lib/renderer');
 const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');

--- a/test/index.js
+++ b/test/index.js
@@ -2,9 +2,12 @@
 
 require('chai').should();
 const { readFileSync } = require('fs');
+const { join } = require('path/posix');
+const { sep } = require('path');
 const Renderer = require('../lib/renderer');
 const source = readFileSync('./test/fixtures/markdownit.md', 'utf8');
 const Hexo = require('hexo');
+const { url_for } = require('hexo-util');
 
 describe('Hexo Renderer Markdown-it', () => {
   const hexo = new Hexo(__dirname, { silent: true });
@@ -355,6 +358,158 @@ describe('Hexo Renderer Markdown-it', () => {
       hexo.extend.renderer.register('md', 'html', renderer, true);
       const result = await hexo.post.render(null, { content: '**foo** {% lorem %}', engine });
       result.content.should.eql('<p><strong>foo</strong> {% lorem %}</p>\n');
+    });
+  });
+
+  describe('image options', () => {
+    const body = '![](/bar/baz.jpg)';
+
+    it('add lazyload attribute', () => {
+      hexo.config.markdown.images = { lazyload: true };
+
+      const renderer = new Renderer(hexo);
+      const result = renderer.render({ text: body });
+
+      result.should.eql('<p><img src="/bar/baz.jpg" alt="" loading="lazy"></p>\n');
+    });
+
+    it('keep lazyload attribute', () => {
+      hexo.config.markdown.images = { lazyload: true };
+
+      const renderer = new Renderer(hexo);
+      const result = renderer.render({ text: body });
+
+      result.should.eql('<p><img src="/bar/baz.jpg" alt="" loading="lazy"></p>\n');
+    });
+
+    it('should prepend root', () => {
+      hexo.config.markdown.images = { prepend_root: true };
+
+      const renderer = new Renderer(hexo);
+      hexo.config.root = '/blog';
+
+      const result = renderer.render({ text: body });
+
+      result.should.eql('<p><img src="/blog/bar/baz.jpg" alt=""></p>\n');
+    });
+
+    describe('post_asset', () => {
+      const Post = hexo.model('Post');
+      const PostAsset = hexo.model('PostAsset');
+
+      beforeEach(() => {
+        hexo.config.post_asset_folder = true;
+        hexo.config.markdown.images = {
+          prepend_root: true,
+          post_asset: true
+        };
+      });
+
+      it('should prepend post path', async () => {
+        const renderer = new Renderer(hexo);
+
+        const asset = 'img/bar.svg';
+        const slug = asset.replace(/\//g, sep);
+        const content = `![](${asset})`;
+        const post = await Post.insert({
+          source: '_posts/foo.md',
+          slug: 'foo'
+        });
+        const postasset = await PostAsset.insert({
+          _id: `source/_posts/foo/${asset}`,
+          slug,
+          post: post._id
+        });
+
+        const expected = url_for.call(hexo, join(post.path, asset));
+        const result = renderer.render({ text: content, path: post.full_source });
+        result.should.eql(`<p><img src="${expected}" alt=""></p>\n`);
+
+        // should not be Windows path
+        expected.includes('\\').should.eql(false);
+
+        await PostAsset.removeById(postasset._id);
+        await Post.removeById(post._id);
+      });
+
+      it('should prepend post path without slug', async () => {
+        const renderer = new Renderer(hexo);
+
+        const asset = 'img/bar.svg';
+        const slug = asset.replace(/\//g, sep);
+        const content = `![](foo/${asset})`;
+        const post = await Post.insert({
+          source: '_posts/foo.md',
+          slug: 'foo'
+        });
+        const postasset = await PostAsset.insert({
+          _id: `source/_posts/foo/${asset}`,
+          slug,
+          post: post._id
+        });
+
+        const expected = url_for.call(hexo, join(post.path, asset));
+        const result = renderer.render({ text: content, path: post.full_source });
+        result.should.eql(`<p><img src="${expected}" alt=""></p>\n`);
+
+        // should not be Windows path
+        expected.includes('\\').should.eql(false);
+
+        await PostAsset.removeById(postasset._id);
+        await Post.removeById(post._id);
+      });
+
+      it('should not modify non-post asset', async () => {
+        const renderer = new Renderer(hexo);
+
+        const asset = 'bar.svg';
+        const siteasset = '/logo/brand.png';
+        const site = 'http://lorem.ipsum/dolor/huri.bun';
+        const content = `![](${asset})![](${siteasset})![](${site})`;
+        const post = await Post.insert({
+          source: '_posts/foo.md',
+          slug: 'foo'
+        });
+        const postasset = await PostAsset.insert({
+          _id: `source/_posts/foo/${asset}`,
+          slug: asset,
+          post: post._id
+        });
+
+        const result = renderer.render({ text: content, path: post.full_source });
+        result.should.eql([
+          `<p><img src="${url_for.call(hexo, join(post.path, asset))}" alt="">`,
+          `<img src="${siteasset}" alt="">`,
+          `<img src="${site}" alt=""></p>`
+        ].join('') + '\n');
+
+        await PostAsset.removeById(postasset._id);
+        await Post.removeById(post._id);
+      });
+
+      it('post located in subfolder', async () => {
+        const renderer = new Renderer(hexo);
+
+        const asset = 'img/bar.svg';
+        const slug = asset.replace(/\//g, sep);
+        const content = `![](${asset})`;
+        const post = await Post.insert({
+          source: '_posts/lorem/foo.md',
+          slug: 'foo'
+        });
+        const postasset = await PostAsset.insert({
+          _id: `source/_posts/lorem/foo/${asset}`,
+          slug,
+          post: post._id
+        });
+
+        const expected = url_for.call(hexo, join(post.path, asset));
+        const result = renderer.render({ text: content, path: post.full_source });
+        result.should.eql(`<p><img src="${expected}" alt=""></p>\n`);
+
+        await PostAsset.removeById(postasset._id);
+        await Post.removeById(post._id);
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request resolves #140, closes #141.

## Usage

_\_posts/foo.md_

```markdown
![](bar.svg)

<!-- Also works: -->

![](foo/bar.svg)
```

will be rendered to:

```html
<p><img src="/post/foo/bar.svg"></p>
<!-- Also works: -->
<p><img src="/post/foo/bar.svg"></p>
```

Note that for some local markdown editor previews, we need to use `![](foo/bar.svg)` to display the image correctly. Adding support for this insertion format can bring users a good local writing experience.
