### PR TITLE
feat: support renderInline

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -56,16 +56,15 @@ class Renderer {
 
   render(data, options) {
     this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
-    
+
     if (options != null && options.inline === true) {
       return this.parser.renderInline(data.text, {
         postPath: data.path
-      })
-    } else {
-      return this.parser.render(data.text, {
-        postPath: data.path
       });
     }
+    return this.parser.render(data.text, {
+      postPath: data.path
+    });
   }
 }
 

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -56,9 +56,16 @@ class Renderer {
 
   render(data, options) {
     this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
-    return this.parser.render(data.text, {
-      postPath: data.path
-    });
+    
+    if (options != null && options.inline === true) {
+      return this.parser.renderInline(data.text, {
+        postPath: data.path
+      })
+    } else {
+      return this.parser.render(data.text, {
+        postPath: data.path
+      });
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -110,6 +110,15 @@ describe('Hexo Renderer Markdown-it', () => {
       const result = renderer.parser.render(text);
       result.should.eql('<pre><code class="lang-js">example\n</code></pre>\n');
     });
+
+    it('render inline', () => {
+      const text = 'inline text';
+      const renderer = new Renderer(hexo);
+      const resultBlock = renderer.render({ text });
+      const resultInline = renderer.render({ text }, { inline: true });
+      resultBlock.should.eql('<p>inline text</p>\n');
+      resultInline.should.eql('inline text');
+    })
   });
 
   describe('plugins', () => {


### PR DESCRIPTION
Support render inline (Single line rendering, without paragraph wrap) which is useful when rendering text inside plugins and tags.

For instance, I would be able to render caption and content without p tag with `inline: true` option:
```js
hexo.extend.tag.register(
  "figure",
  function ([caption], content) {
    return `<figure>${hexo.render.renderSync(
      {
        text: content,
        engine: "markdown",
      },
      {
        inline: true,
      }
    )}<figcaption>${hexo.render.renderSync(
      {
        text: caption,
        engine: "markdown",
      },
      {
        inline: true,
      }
    )}</figcaption></figure>`;
  },
  { ends: true }
);
```