### PR TITLE
fix: cannot find installed markdown-it plugin by yarn v3 monorepo

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -40,14 +40,14 @@ class Renderer {
         if (pugs instanceof Object && pugs.name) {
           const resolved = require.resolve(pugs.name, {
             paths: [
-              // find from root hexo base directory
-              hexo.base_dir,
               // find from root hexo base directory node_modules
               path.join(hexo.base_dir, 'node_modules'),
-              // find from current library directory
-              path.join(__dirname, '../'),
               // find from current installed library node_modules
               path.join(__dirname, '../node_modules'),
+              // find from root hexo base directory
+              hexo.base_dir,
+              // find from current library directory
+              path.join(__dirname, '../'),
             ],
           });
           return parser.use(require(resolved), pugs.options);

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-const MarkdownIt = require("markdown-it");
+const MarkdownIt = require('markdown-it');
 
 class Renderer {
   /**
@@ -14,7 +14,7 @@ class Renderer {
     let { markdown } = hexo.config;
 
     // Temporary backward compatibility
-    if (typeof markdown === "string") {
+    if (typeof markdown === 'string') {
       markdown = {
         preset: markdown,
       };
@@ -42,11 +42,11 @@ class Renderer {
               // find from root hexo base directory
               hexo.base_dir,
               // find from root hexo base directory node_modules
-              path.join(hexo.base_dir, "node_modules"),
+              path.join(hexo.base_dir, 'node_modules'),
               // find from current library directory
-              path.join(__dirname, "../"),
+              path.join(__dirname, '../'),
               // find from current installed library node_modules
-              path.join(__dirname, "../node_modules"),
+              path.join(__dirname, '../node_modules'),
             ],
           });
           return parser.use(require(resolved), pugs.options);
@@ -56,11 +56,11 @@ class Renderer {
     }
 
     if (anchors) {
-      this.parser.use(require("./anchors"), anchors);
+      this.parser.use(require('./anchors'), anchors);
     }
 
     if (images) {
-      this.parser.use(require("./images"), {
+      this.parser.use(require('./images'), {
         images,
         hexo: this.hexo,
       });
@@ -68,7 +68,7 @@ class Renderer {
   }
 
   render(data, options) {
-    this.hexo.execFilterSync("markdown-it:renderer", this.parser, { context: this });
+    this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
     return this.parser.render(data.text, {
       postPath: data.path,
     });

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MarkdownIt = require('markdown-it');
+const path = require('path');
 
 class Renderer {
   /**

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,9 +1,8 @@
-'use strict';
+"use strict";
 
-const MarkdownIt = require('markdown-it');
+const MarkdownIt = require("markdown-it");
 
 class Renderer {
-
   /**
    * constructor
    *
@@ -15,11 +14,13 @@ class Renderer {
     let { markdown } = hexo.config;
 
     // Temporary backward compatibility
-    if (typeof markdown === 'string') {
+    if (typeof markdown === "string") {
       markdown = {
-        preset: markdown
+        preset: markdown,
       };
-      hexo.log.warn(`Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`);
+      hexo.log.warn(
+        `Deprecated config detected. Please use\n\nmarkdown:\n  preset: ${markdown.preset}\n\nSee https://github.com/hexojs/hexo-renderer-markdown-it#options`
+      );
     }
 
     const { preset, render, enable_rules, disable_rules, plugins, anchors, images } = markdown;
@@ -36,28 +37,40 @@ class Renderer {
     if (plugins) {
       this.parser = plugins.reduce((parser, pugs) => {
         if (pugs instanceof Object && pugs.name) {
-          return parser.use(require(pugs.name), pugs.options);
+          const resolved = require.resolve(pugs.name, {
+            paths: [
+              // find from root hexo base directory
+              hexo.base_dir,
+              // find from root hexo base directory node_modules
+              path.join(hexo.base_dir, "node_modules"),
+              // find from current library directory
+              path.join(__dirname, "../"),
+              // find from current installed library node_modules
+              path.join(__dirname, "../node_modules"),
+            ],
+          });
+          return parser.use(require(resolved), pugs.options);
         }
         return parser.use(require(pugs));
       }, this.parser);
     }
 
     if (anchors) {
-      this.parser.use(require('./anchors'), anchors);
+      this.parser.use(require("./anchors"), anchors);
     }
 
     if (images) {
-      this.parser.use(require('./images'), {
+      this.parser.use(require("./images"), {
         images,
-        hexo: this.hexo
+        hexo: this.hexo,
       });
     }
   }
 
   render(data, options) {
-    this.hexo.execFilterSync('markdown-it:renderer', this.parser, { context: this });
+    this.hexo.execFilterSync("markdown-it:renderer", this.parser, { context: this });
     return this.parser.render(data.text, {
-      postPath: data.path
+      postPath: data.path,
     });
   }
 }


### PR DESCRIPTION
fixed cannot find some markdown-it plugin which installed by yarn berry.

error logs before fixed:
```log
ERROR Plugin load failed: hexo-renderers
Error: Cannot find module 'markdown-it-table-of-contents'
Require stack:
- D:\Repositories\hexo-renderers\lib\dist\markdown-it\renderer.js
- D:\Repositories\hexo-renderers\lib\dist\renderer-markdown-it.js
- D:\Repositories\hexo-renderers\lib\dist\renderer-loader.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:931:15)
    at Function.Module._load (internal/modules/cjs/loader.js:774:27)
    at Module.require (internal/modules/cjs/loader.js:1003:19)
    at require (internal/modules/cjs/helpers.js:107:18)
    at D:\Repositories\hexo-renderers\lib\dist\markdown-it\renderer.js:38:39
    at Array.reduce (<anonymous>)
    at new Renderer (D:\Repositories\hexo-renderers\lib\dist\markdown-it\renderer.js:33:35)       
    at rendererMarkdownIt (D:\Repositories\hexo-renderers\lib\dist\renderer-markdown-it.js:103:20)    at D:\Repositories\hexo-renderers\lib\dist\renderer-loader.js:56:9
    at D:\Repositories\hexo-renderers\test\node_modules\hexo\dist\hexo\index.js:272:20
    at tryCatcher (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\promise.js:547:31)
    at Promise._settlePromise (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\promise.js:604:18)
    at Promise._settlePromise0 (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\promise.js:649:10)
    at Promise._settlePromises (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\promise.js:729:18)
    at _drainQueueStep (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\async.js:93:12)
    at _drainQueue (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\async.js:86:9)
    at Async._drainQueues (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (D:\Repositories\hexo-renderers\test\node_modules\bluebird\js\release\async.js:15:14)
    at processImmediate (internal/timers.js:464:21)
```

fixed on `hexo server`
![image](https://github.com/hexojs/hexo-renderer-markdown-it/assets/12471057/fefdac5c-e10a-4cd4-91fe-6a7d3beb0e14)
