### PR TITLE
Fixes "alt" tag not showing, when `images` option is used

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -13,6 +13,8 @@ function images(md, opts) {
     const token = tokens[idx];
     const { postPath } = env;
 
+    token.attrSet('alt', token.content);
+
     if (lazyload) {
       token.attrSet('loading', 'lazy');
     }

--- a/test/index.js
+++ b/test/index.js
@@ -118,7 +118,7 @@ describe('Hexo Renderer Markdown-it', () => {
       const resultInline = renderer.render({ text }, { inline: true });
       resultBlock.should.eql('<p>inline text</p>\n');
       resultInline.should.eql('inline text');
-    })
+    });
   });
 
   describe('plugins', () => {
@@ -401,6 +401,15 @@ describe('Hexo Renderer Markdown-it', () => {
       const result = renderer.render({ text: body });
 
       result.should.eql('<p><img src="/blog/bar/baz.jpg" alt=""></p>\n');
+    });
+
+    it('alt text', () => {
+      hexo.config.markdown.images = { test: true };
+
+      const renderer = new Renderer(hexo);
+      const result = renderer.render({ text: '![alt text](/bar/baz.jpg)' });
+
+      result.should.eql('<p><img src="/bar/baz.jpg" alt="alt text"></p>\n');
     });
 
     describe('post_asset', () => {


### PR DESCRIPTION
## Problem
When using the `images:` config option, the `alt` tag doesn't get added to the attributes.

**Steps to Reproduce**
- Set images in hexo `_config.yml` file
``` yaml
markdown:
  images:
    lazyload: true // Need at least one option, this is just an example
```
- Note the generated `<img .../>` tags in HTML don't have any `alt` attributes

## Fix
Use the `token.content` which contains the "alt text" from the markdown image.

_Example markdown image_
![image](https://github.com/hexojs/hexo-renderer-markdown-it/assets/11782590/81778573-8158-47f4-8caf-3adf135561df)

_What's available in the context during debugging_
![image](https://github.com/hexojs/hexo-renderer-markdown-it/assets/11782590/0853303e-c576-4527-9061-6e54d41ad37e)

_Note: I'm not sure if it would be better to fix this up the call-chain :shrug:_

- Fixes #205