### PR TITLE
feat: support ESM plugins or plugins with named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ markdown:
           laughing: ':D'
     - name: 'other-plugin'
       options: ...
+    # For ESM plugins or plugins with named exports
+    - name: 'some-esm-plugin'
+      import: 'default' # Optional, defaults to 'default'
+      options: ...
 ```
 
 ## Extensibility

--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -50,7 +50,17 @@ class Renderer {
               path.join(__dirname, '../'),
             ],
           });
-          return parser.use(require(resolved), pugs.options);
+
+          let plugin = require(resolved);
+          if (typeof plugin === 'object') {
+            const key = pugs.import || 'default';
+            if (!plugin[key]) {
+              throw new Error(`Cannot find export '${key}' from module '${pugs.name}'. Available exports: ${Object.keys(plugin).join(', ')}`);
+            }
+            plugin = plugin[key];
+          }
+
+          return parser.use(plugin, pugs.options);
         }
         return parser.use(require(pugs));
       }, this.parser);

--- a/test/fixtures/plugin_esm_mock.js
+++ b/test/fixtures/plugin_esm_mock.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  default: function(md) {
+    md.core.ruler.push('esm_default', state => {
+      state.tokens.push(new state.Token('esm_default', '', 0));
+    });
+    md.renderer.rules.esm_default = function() { return '[[esm_default]]'; };
+  },
+
+  named: function(md) {
+    md.core.ruler.push('esm_named', state => {
+      state.tokens.push(new state.Token('esm_named', '', 0));
+    });
+    md.renderer.rules.esm_named = function() { return '[[esm_named]]'; };
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -160,6 +160,33 @@ describe('Hexo Renderer Markdown-it', () => {
       const result = renderer.parser.render(text);
       result.should.equal('<p>:lorem:</p>\n');
     });
+
+    it('esm plugin - default export', () => {
+      hexo.config.markdown.plugins = [
+        {
+          name: require('path').join(__dirname, 'fixtures/plugin_esm_mock')
+        }
+      ];
+
+      const text = 'text';
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(text);
+      result.should.contain('[[esm_default]]');
+    });
+
+    it('esm plugin - named export', () => {
+      hexo.config.markdown.plugins = [
+        {
+          name: require('path').join(__dirname, 'fixtures/plugin_esm_mock'),
+          import: 'named'
+        }
+      ];
+
+      const text = 'text';
+      const renderer = new Renderer(hexo);
+      const result = renderer.parser.render(text);
+      result.should.contain('[[esm_named]]');
+    });
   });
 
   describe('anchors', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Add test cases for the changes.
- [x] Passed the CI test.

## Description

This PR adds support for loading plugins that use ESM-style exports (interop) or named exports.

Previously, the renderer assumed that `require('plugin-name')` would directly return the plugin function. However, some modern plugins or dual-mode packages might export the plugin function under a `default` property or a specific named export.

With this change, users can now specify an `import` property in the plugin configuration to choose which export to use.

Logic:

- If the required module is an object and the user specifies an `import` key (or defaults to `'default'`), it tries to use that property.
- If the property doesn't exist, it throws a descriptive error listing available exports.
- Fallback behavior is preserved for standard CommonJS plugins.

Example Config:

```yaml
plugins:
  - name: 'some-esm-plugin'
    import: 'default' # Optional, defaults to 'default' if the module is an object
    options: ...
```

## Additional information

- Updated `README.md` with usage examples for the new feature.
- Added unit tests covering default and named exports.
